### PR TITLE
ENH: Changes diagram generation and probability calculations to work in terms of lists of edges instead of NetworkX diagrams

### DIFF
--- a/kda/calculations.py
+++ b/kda/calculations.py
@@ -523,6 +523,8 @@ def calc_state_probs_from_diags(G, dirpar_edges, key, output_strings=False):
     n_dirpars = dirpar_edges.shape[0]
     # get the number of partial diagrams
     n_partials = int(n_dirpars / n_states)
+    # retrieve the rate matrix from G
+    Kij = graph_utils.retrieve_rate_matrix(G)
 
     edge_value = G.edges[list(G.edges)[0]][key]
     if not output_strings:
@@ -534,10 +536,12 @@ def calc_state_probs_from_diags(G, dirpar_edges, key, output_strings=False):
         dirpar_rate_products = np.ones(n_dirpars, dtype=float)
         # iterate over the directional partial diagrams
         for i, edge_list in enumerate(dirpar_edges):
-            # iterate over the edges in the given directional partial diagram i
-            for edge in edge_list:
-                # multiply the rate of each edge
-                dirpar_rate_products[i] *= G.edges[edge][key]
+            # for each edge list, retrieve an array of the ith and jth indices,
+            # retrieve the values associated with each (i, j) pair, and
+            # calculate the product of those values
+            Ki = edge_list[:, 0]
+            Kj = edge_list[:, 1]
+            dirpar_rate_products[i] = np.prod(Kij[Ki, Kj])
 
         state_mults = dirpar_rate_products.reshape(n_states, n_partials).sum(axis=1)
         state_probs = state_mults / math.fsum(dirpar_rate_products)

--- a/kda/calculations.py
+++ b/kda/calculations.py
@@ -567,7 +567,9 @@ def calc_state_probs_from_diags(G, dirpar_edges, key, output_strings=False):
         return state_mults, norm
 
 
-def calc_net_cycle_flux_from_diags(G, dirpars, cycle, order, key, output_strings=False):
+def calc_net_cycle_flux_from_diags(
+    G, dirpar_edges, cycle, order, key, output_strings=False
+):
     """
     Calculates net cycle flux and generates analytic function strings from
     input diagram and directional partial diagrams. If directional partial
@@ -578,9 +580,8 @@ def calc_net_cycle_flux_from_diags(G, dirpars, cycle, order, key, output_strings
     ----------
     G : NetworkX MultiDiGraph Object
         Input diagram.
-    dirpars : list
-        List of all directional partial diagrams for a given set of partial
-        diagrams.
+    dirpar_edges : array
+        Array of all directional partial diagram edges (made from 2-tuples).
     cycle : list of int
         List of node indices for cycle of interest, index zero. Order of node
         indices does not matter.
@@ -607,7 +608,7 @@ def calc_net_cycle_flux_from_diags(G, dirpars, cycle, order, key, output_strings
             G, cycle, order, key, output_strings=output_strings
         )
         sigma_K = calc_sigma_K(G, cycle, flux_diags, key, output_strings=output_strings)
-        sigma = calc_sigma(G, dirpars, key, output_strings=output_strings)
+        sigma = calc_sigma(G, dirpar_edges, key, output_strings=output_strings)
         net_cycle_flux = pi_diff * sigma_K / sigma
         return net_cycle_flux
     if output_strings == True:
@@ -617,7 +618,7 @@ def calc_net_cycle_flux_from_diags(G, dirpars, cycle, order, key, output_strings
         sigma_K_str = calc_sigma_K(
             G, cycle, flux_diags, key, output_strings=output_strings
         )
-        sigma_str = calc_sigma(G, dirpars, key, output_strings=output_strings)
+        sigma_str = calc_sigma(G, dirpar_edges, key, output_strings=output_strings)
         sympy_net_cycle_flux_func = expressions.construct_sympy_net_cycle_flux_func(
             pi_diff_str, sigma_K_str, sigma_str
         )

--- a/kda/calculations.py
+++ b/kda/calculations.py
@@ -27,8 +27,6 @@ from sympy import parse_expr, logcombine
 from kda import graph_utils, diagrams, expressions
 from kda.exceptions import CycleError
 
-from memory_profiler import profile
-
 
 def _get_ordered_cycle(G, input_cycle):
     """
@@ -485,7 +483,6 @@ def calc_net_cycle_flux(G, cycle, order, key, output_strings=False):
         return sympy_net_cycle_flux_func
 
 
-@profile
 def calc_state_probs_from_diags(G, dirpar_edges, key, output_strings=False):
     """
     Calculates state probabilities and generates analytic function strings from
@@ -497,9 +494,8 @@ def calc_state_probs_from_diags(G, dirpar_edges, key, output_strings=False):
     ----------
     G : NetworkX MultiDiGraph
         Input diagram
-    dirpar_edges : list
-        List of all directional partial diagrams for a given set of partial
-        diagrams.
+    dirpar_edges : array
+        Array of all directional partial diagram edges (made from 2-tuples).
     key : str
         Definition of key in NetworkX diagram edges, used to call edge rate
         values or names. This needs to match the key used for the rate

--- a/kda/diagrams.py
+++ b/kda/diagrams.py
@@ -373,22 +373,18 @@ def generate_partial_diagrams(G, return_edges=False):
         edges = np.vstack((edges, rev_edges))
         # add the edges to the base diagram
         partial.add_edges_from(edges)
-        # count the number of cycles in the diagram
-        # `nx.simple_cycles()` returns cycles composed of just 2 nodes, so
-        # we have to subtract out the number of connections. This way `n_cycles`
-        # will be zero unless there is an actual multi-node cycle present
-        # if the number of simple cycles is zero
-        # this is a valid partial diagram
+        # if the constructed partial diagram is a
+        # tree, it is a valid diagram
         if nx.is_tree(partial):
             if return_edges:
                 unique_partial_edges.append(list(partial.edges()))
             else:
                 partial_diagrams.append(partial)
 
-    if not return_edges:
-        return partial_diagrams
-    else:
+    if return_edges:
         return np.asarray(unique_partial_edges, dtype=int)
+    else:
+        return partial_diagrams
 
 
 def generate_directional_partial_diagrams(G, return_edges=False):

--- a/kda/graph_utils.py
+++ b/kda/graph_utils.py
@@ -10,6 +10,7 @@ This file contains a host of utility functions for NetworkX graphs.
 
 .. autofunction:: generate_K_string_matrix
 .. autofunction:: generate_edges
+.. autofunction:: retrieve_rate_matrix
 .. autofunction:: add_node_attribute
 .. autofunction:: add_graph_attribute
 .. autofunction:: find_all_unique_cycles
@@ -86,6 +87,35 @@ def generate_edges(G, vals, names=None, val_key="val", name_key="name"):
                 G.add_edge(i, j, **attrs)
 
 
+def retrieve_rate_matrix(G, key="val"):
+    """
+    Retrieves rate matrix from edge data stored in input diagram G.
+
+    Parameters
+    ----------
+    G : NetworkX MultiDiGraph
+        Input diagram
+    val : str (optional)
+        Key used to retrieve values from edges. Default is 'val'.
+
+    Returns
+    -------
+    rate_matrix : array
+        'NxN' array where 'N' is the number of nodes/states in the diagram G.
+        Contains the values/rates for each edge.
+    """
+    # get the number of states
+    n_states = G.number_of_nodes()
+    # create `n_states x n_states` zero-array
+    rate_matrix = np.zeros(shape=(n_states, n_states), dtype=float)
+    # iterate over edges
+    for edge in G.edges(data=True):
+        i, j, data = edge
+        # use edge indices and edge values to construct rate matrix
+        rate_matrix[i, j] = data[key]
+    return rate_matrix
+
+
 def add_node_attribute(G, data, label):
     """
     Sequentially add attributes to nodes from array of values, i.e. state
@@ -142,8 +172,6 @@ def find_all_unique_cycles(G):
         reverse_cycle = [cycle[0]] + cycle[len(G.nodes) : 0 : -1]
         if not reverse_cycle in temp:
             unique_cycles.append(cycle)
-    if len(unique_cycles) == 1:
-        print("Only 1 cycle found: {}".format(unique_cycles[0]))
     return unique_cycles
 
 

--- a/kda/ode.py
+++ b/kda/ode.py
@@ -74,7 +74,8 @@ def ode_solver(P, K, t_max, tol=1e-16, **options):
 
     def terminate(t, y):
         y_prime = np.matmul(k, y, dtype=np.float64)
-        if all(elem < tol for elem in y_prime) == True:
+        if all(elem < tol for elem in y_prime):
+            print(f"\n kda.ode.ode_solver() reached convergence at t={t}\n")
             return False
         else:
             return True

--- a/kda/scripts/verification.py
+++ b/kda/scripts/verification.py
@@ -23,7 +23,7 @@ from numpy.testing import assert_allclose
 import pandas as pd
 import networkx as nx
 
-from kda import calculations, diagrams, graph_utils, svd, ode
+from kda import calculations, diagrams, graph_utils, svd
 from multibind import nonequilibrium
 
 

--- a/kda/tests/test_kda.py
+++ b/kda/tests/test_kda.py
@@ -625,14 +625,16 @@ class Test_Flux_Calcs:
         G = nx.MultiDiGraph()
         graph_utils.generate_edges(G, K)
         # generate the directional partial diagrams
-        dirpars = diagrams.generate_directional_partial_diagrams(G)
+        dirpar_edges = diagrams.generate_directional_partial_diagrams(
+            G, return_edges=True
+        )
         # pick one of the 3-node cycles and the CCW direction
         cycle = [0, 1, 3]
         order = [0, 1]
         # calculate the net cycle flux
         net_cycle_flux = calculations.calc_net_cycle_flux_from_diags(
             G,
-            dirpars=dirpars,
+            dirpar_edges=dirpar_edges,
             cycle=cycle,
             order=order,
             key="val",
@@ -641,7 +643,7 @@ class Test_Flux_Calcs:
         # generate the net cycle flux function
         net_cycle_flux_sympy_func = calculations.calc_net_cycle_flux_from_diags(
             G,
-            dirpars=dirpars,
+            dirpar_edges=dirpar_edges,
             cycle=cycle,
             order=order,
             key="name",
@@ -854,11 +856,11 @@ class Test_Diagram_Generation:
         graph_utils.generate_edges(G, K)
         # generate the partial diagrams and verify
         # they agree with the expected value
-        partials = diagrams.generate_partial_diagrams(G)
+        partials = diagrams.generate_partial_diagrams(G, return_edges=False)
         assert len(partials) == expected_pars
         # generate the directional partial diagrams and verify
         # they agree with the expected value
-        dirpars = diagrams.generate_directional_partial_diagrams(G)
+        dirpars = diagrams.generate_directional_partial_diagrams(G, return_edges=False)
         assert len(dirpars) == expected_dirpars
         # count the number of partial diagrams
         # and verify they agree with the expected value
@@ -875,14 +877,16 @@ class Test_Diagram_Generation:
         graph_utils.generate_edges(G, K)
         # generate the partial diagrams and verify
         # they agree with the expected value
-        partials = diagrams.generate_partial_diagrams(G)
+        partial_edges = diagrams.generate_partial_diagrams(G, return_edges=True)
         expected_pars = n_states ** (n_states - 2)
-        assert len(partials) == expected_pars
+        assert len(partial_edges) == expected_pars
         # generate the directional partial diagrams and verify
         # they agree with the expected value
-        dirpars = diagrams.generate_directional_partial_diagrams(G)
+        dirpar_edges = diagrams.generate_directional_partial_diagrams(
+            G, return_edges=True
+        )
         expected_dirpars = n_states ** (n_states - 1)
-        assert len(dirpars) == expected_dirpars
+        assert len(dirpar_edges) == expected_dirpars
         # count the number of partial diagrams
         # and verify they agree with the expected value
         n_pars = diagrams.enumerate_partial_diagrams(K)
@@ -952,13 +956,13 @@ def test_function_inputs():
     G = nx.MultiDiGraph()
     graph_utils.generate_edges(G, K)
     # generate the directional partial diagrams
-    dirpars = diagrams.generate_directional_partial_diagrams(G)
+    dirpar_edges = diagrams.generate_directional_partial_diagrams(G, return_edges=True)
 
     # test both cases for calc_sigma()
     with pytest.raises(TypeError):
-        calculations.calc_sigma(G, dirpars, key="name", output_strings=False)
+        calculations.calc_sigma(G, dirpar_edges, key="name", output_strings=False)
     with pytest.raises(TypeError):
-        calculations.calc_sigma(G, dirpars, key="val", output_strings=True)
+        calculations.calc_sigma(G, dirpar_edges, key="val", output_strings=True)
 
     # pick one of the 3-node cycles and generate the flux diagrams for it
     cycle = [0, 1, 3]
@@ -993,9 +997,9 @@ def test_function_inputs():
     # test both cases for calc_state_probs_from_diags()
     with pytest.raises(TypeError):
         calculations.calc_state_probs_from_diags(
-            G, dirpars, key="name", output_strings=False
+            G, dirpar_edges, key="name", output_strings=False
         )
     with pytest.raises(TypeError):
         calculations.calc_state_probs_from_diags(
-            G, dirpars, key="val", output_strings=True
+            G, dirpar_edges, key="val", output_strings=True
         )


### PR DESCRIPTION
* Updates `diagrams.generate_partial_diagrams()` to only store
edges if `return_edges=True`

* Updates `diagrams.generate_directional_partial_diagrams()` to
only store edges if `return_edges=True`

* Changes various `kda.calculations` functions to use edges to lower
memory footprint of functions

* Optimizes code by replacing many python for-loops with numpy array
operations for better performance

* Addresses edge tuple portion of issue #2 

## Status
- [ ] Ready to go