### PR TITLE
ENH, TST: Cleans up `plotting.py` and adds new tests for `graph_utils.py`

### DIFF
--- a/kda/graph_utils.py
+++ b/kda/graph_utils.py
@@ -76,7 +76,7 @@ def generate_edges(G, vals, names=None, val_key="val", name_key="name"):
         raise TypeError(
             "Values entered for 'vals' must be integers or floats, not strings."
         )
-    elif not isinstance(names[0, 0], str):
+    if not isinstance(names[0, 0], str):
         raise TypeError("Labels entered for 'names' must be strings.")
     np.fill_diagonal(vals, 0)  # Make sure diagonal elements are set to zero
 
@@ -196,7 +196,7 @@ def _is_ccw(cycle, start, end):
     for i in range(len(double) - 1):
         if (double[i], double[i + 1]) == (start, end):
             return True
-    return None
+    return False
 
 
 def get_ccw_cycle(cycle, order):
@@ -214,10 +214,7 @@ def get_ccw_cycle(cycle, order):
         input cycle. This pair of nodes is used to determine which direction is
         CCW.
     """
-    CCW = _is_ccw(cycle, order[0], order[1])
-    if CCW == True:
+    if _is_ccw(cycle, order[0], order[1]):
         return cycle
-    elif not CCW:
-        return cycle[::-1]
     else:
-        raise CycleError("Direction of cycle {} could not be determined.".format(cycle))
+        return cycle[::-1]

--- a/kda/graph_utils.py
+++ b/kda/graph_utils.py
@@ -21,6 +21,8 @@ This file contains a host of utility functions for NetworkX graphs.
 import numpy as np
 import networkx as nx
 
+from kda.exceptions import CycleError
+
 
 def generate_K_string_matrix(N_states):
     """
@@ -214,6 +216,8 @@ def get_ccw_cycle(cycle, order):
         input cycle. This pair of nodes is used to determine which direction is
         CCW.
     """
+    if not all(i in cycle for i in order):
+        raise CycleError(f"Input node indices {order} do not exist in cycle {cycle}")
     if _is_ccw(cycle, order[0], order[1]):
         return cycle
     else:

--- a/kda/tests/test_kda.py
+++ b/kda/tests/test_kda.py
@@ -848,21 +848,9 @@ class Test_Misc_Funcs:
     @pytest.mark.parametrize(
         "cycle, cycle_order, expected_func",
         [
-            (
-                [0, 3, 2, 1],
-                [3, 0],
-                "log(k12*k23*k34*k41/(k14*k21*k32*k43))",
-            ),
-            (
-                [0, 3, 1],
-                [3, 0],
-                "log(k12*k24*k41/(k14*k21*k42))",
-            ),
-            (
-                [1, 3, 2],
-                [3, 1],
-                "log(k23*k34*k42/(k24*k32*k43))",
-            ),
+            ([0, 3, 2, 1], [3, 0], "log(k12*k23*k34*k41/(k14*k21*k32*k43))",),
+            ([0, 3, 1], [3, 0], "log(k12*k24*k41/(k14*k21*k42))",),
+            ([1, 3, 2], [3, 1], "log(k23*k34*k42/(k24*k32*k43))",),
         ],
     )
     def test_thermo_force_4WL(self, k_vals, cycle, cycle_order, expected_func):
@@ -1142,19 +1130,9 @@ def test_add_attributes():
 
 
 def test_generate_edges_errors():
-    k_vals = np.array(
-        [
-            [0, 1, 2],
-            [5, 0, 6],
-            [9, 10, 0],
-        ]
-    )
+    k_vals = np.array([[0, 1, 2], [5, 0, 6], [9, 10, 0],])
     k_names = np.array(
-        [
-            ["k11", "k12", "k13"],
-            ["k21", "k22", "k23"],
-            ["k31", "k32", "k33"],
-        ]
+        [["k11", "k12", "k13"], ["k21", "k22", "k23"], ["k31", "k32", "k33"],]
     )
 
     # initialize graph object

--- a/kda/tests/test_kda.py
+++ b/kda/tests/test_kda.py
@@ -1192,4 +1192,10 @@ def test_ccw():
         # to make some assertions here. The problem is defining what CCW means
         # is problem-dependent, and you have to choose node positions to make
         # that decision, which would appear arbitrary here.
-        graph_utils.get_ccw_cycle(cycle, order=cycle[:2])
+        new_cycle = graph_utils.get_ccw_cycle(cycle, order=cycle[:2])
+        # since we feed in an order that is just the first 2 nodes of the
+        # cycle, this should return the same cycle
+        assert cycle == new_cycle
+
+    with pytest.raises(CycleError):
+        graph_utils.get_ccw_cycle(cycles[0], [4, 5, 6])

--- a/kda/tests/test_plotting.py
+++ b/kda/tests/test_plotting.py
@@ -68,27 +68,40 @@ def results_4wl():
     return results4wl
 
 
-def test_plot_diagram(G4wl, pos_4wl):
-    plotting.draw_diagrams(G4wl)
-    plotting.draw_diagrams(G4wl, pos=pos_4wl)
-
-
 def test_plot_cycle(G4wl, pos_4wl):
-    plotting.draw_cycles(G4wl, [0, 1, 3])
-    plotting.draw_cycles(G4wl, [0, 3, 2, 1])
-    plotting.draw_cycles(G4wl, [0, 1, 3], pos=pos_4wl)
-    plotting.draw_cycles(G4wl, [0, 1, 3], pos=pos_4wl, cbt=True)
-    plotting.draw_cycles(G4wl, [[0, 1, 3], [0, 3, 2, 1]], panel=True)
-    plotting.draw_cycles(G4wl, [[0, 1, 3], [0, 3, 2, 1]], panel=True, cbt=True)
-    plotting.draw_cycles(G4wl, [[0, 1, 3], [0, 3, 2, 1]], cbt=True)
+    cycles = [[0, 1, 3], [0, 3, 2, 1]]
+    plotting.draw_cycles(G4wl, cycles[0])
+    plotting.draw_cycles(G4wl, cycles[1])
+    plotting.draw_cycles(G4wl, cycles[0], pos=pos_4wl)
+    plotting.draw_cycles(G4wl, cycles[0], pos=pos_4wl, cbt=True)
+    plotting.draw_cycles(G4wl, cycles, panel=True)
+    plotting.draw_cycles(G4wl, cycles, panel=True, cbt=True)
+    plotting.draw_cycles(G4wl, cycles, cbt=True)
+    cycles = 4 * cycles
+    plotting.draw_cycles(G4wl, cycles[:-1], panel=True, cbt=True)
 
 
 def test_plot_diagrams(G4wl, pos_4wl):
-    flux_diags = diagrams.generate_flux_diagrams(G4wl, [0, 1, 3])
+    plotting.draw_diagrams(G4wl)
+    plotting.draw_diagrams(G4wl, pos=pos_4wl)
+    cycles = graph_utils.find_all_unique_cycles(G4wl)
+
+    flux_diags = []
+    for cycle in cycles:
+        if not cycle is None:
+            flux_diags = diagrams.generate_flux_diagrams(G4wl, cycle)
+            if not flux_diags is None:
+                flux_diags.extend(flux_diags)
+
     plotting.draw_diagrams(flux_diags)
     plotting.draw_diagrams(flux_diags, pos=pos_4wl, cbt=True)
     plotting.draw_diagrams(flux_diags, pos=pos_4wl, panel=True, cbt=True)
+    plotting.draw_diagrams(flux_diags, pos=pos_4wl, panel=True, cbt=False, rows=2)
+    plotting.draw_diagrams(flux_diags, pos=pos_4wl, panel=True, cbt=False, cols=2)
+    flux_diags = 2 * flux_diags
+    plotting.draw_diagrams(flux_diags[:-1], pos=pos_4wl, panel=True, cbt=False)
 
 
 def test_plot_ODE_probs(results_4wl):
     plotting.draw_ODE_results(results_4wl)
+    plotting.draw_ODE_results(results_4wl, bbox_coords=(0, 1))


### PR DESCRIPTION
## Description
* General cleanup to `plotting.py`:
  - Replaces all `==` comparisons
  - Adds arc to arrows such that double arrows are differentiable
  - Standardizes edge drawing settings so all figures should be the same
  - Moves repeated code into smaller functions
  - Fixes issue with `plotting.draw_cycles()` where
    subplot scales were heterogeneous
  - Closes `matplotlib` figures so unclosed figures don't accumulate

* Changes to `test_plotting.py`:
  - Moves tests from `test_plot_diagram` to `test_plot_diagrams` since
    these are testing the same function
  - Adds additional test cases to `test_plot_cycle` and
    `test_plot_diagrams` to cover a few lines that were
     not previously being covered

* Adds `test_add_attributes`, `test_generate_edges_errors`,
and `test_ccw` to `test_kda.py`

* Cleans up `graph_utils.is_ccw()` and `graph_utils.get_ccw_cycle()`

## Status
- [x] Ready to go