### PR TITLE
MAINT: Simplify `generate_directional_partial_diagrams()` and change to "directional diagrams"

### DIFF
--- a/kda/calculations.py
+++ b/kda/calculations.py
@@ -418,7 +418,7 @@ def calc_state_probs(G, key, output_strings=False):
     state_probs_sympy : SymPy object
         List of analytic SymPy state probability functions.
     """
-    dirpar_edges = diagrams.generate_directional_partial_diagrams(G, return_edges=True)
+    dirpar_edges = diagrams.generate_directional_diagrams(G, return_edges=True)
     if output_strings == False:
         state_probs = calc_state_probs_from_diags(
             G, dirpar_edges, key, output_strings=output_strings
@@ -460,7 +460,7 @@ def calc_net_cycle_flux(G, cycle, order, key, output_strings=False):
     net_cycle_flux_func : SymPy object
         Analytic net cycle flux SymPy function.
     """
-    dirpar_edges = diagrams.generate_directional_partial_diagrams(G, return_edges=True)
+    dirpar_edges = diagrams.generate_directional_diagrams(G, return_edges=True)
     flux_diags = diagrams.generate_flux_diagrams(G, cycle)
     if output_strings == False:
         pi_diff = calc_pi_difference(

--- a/kda/scripts/README.md
+++ b/kda/scripts/README.md
@@ -104,7 +104,7 @@ A third directory, `/data`, is created for storing all of the other pertinent
 information, where a `_data.csv` file is stored for each execution of
 `verification.py`. Each `_data.csv` file contains the graph index, number of
 states, number of edges/rates, number of cycles in the diagram, number of
-partial diagrams generated, number of directional partial diagrams generated,
+partial diagrams generated, number of directional diagrams generated,
 steady state probabilities, and SVD/KDA run time information for each run case.
 
 ### rmsd.py

--- a/kda/scripts/verification.py
+++ b/kda/scripts/verification.py
@@ -189,7 +189,7 @@ def check_diagram_counts(G, K, dirpar_edges, n_states):
     Uses KDA function to calculate the theoretical number of partial diagrams
     and verifies that it agrees with the number of partial diagrams generated
     for the state probability calculations. Also verifies that the number of
-    generated directional partial diagrams agree with the theoretical value.
+    generated directional diagrams agree with the theoretical value.
     """
     n_pars_theoretical = diagrams.enumerate_partial_diagrams(K0=K)
     # generate the partial diagrams for counting purposes
@@ -201,7 +201,7 @@ def check_diagram_counts(G, K, dirpar_edges, n_states):
             f"Expected {n_pars_theoretical} partials, generated {n_pars} partials."
         )
     n_dirpars = len(dirpar_edges)
-    # check that the number of directional partial diagrams are equal to
+    # check that the number of directional diagrams are equal to
     # the number of states times the number of partial diagrams
     assert n_dirpars == n_states * n_pars
     return n_pars, n_dirpars
@@ -419,11 +419,11 @@ def main(
         kda_start = time.perf_counter()
         # use KDA to generate the edges from the rate matrix
         graph_utils.generate_edges(G, K, names=None)
-        # generate the directional partial diagrams for calculations
-        dirpar_edges = diagrams.generate_directional_partial_diagrams(
+        # generate the directional diagrams for calculations
+        dirpar_edges = diagrams.generate_directional_diagrams(
             G, return_edges=True
         )
-        # use input diagram and directional partial diagrams to calculate
+        # use input diagram and directional diagrams to calculate
         # the state probabilities
         kda_probs = calculations.calc_state_probs_from_diags(G, dirpar_edges, key="val")
         kda_elapsed = time.perf_counter() - kda_start

--- a/kda/tests/test_kda.py
+++ b/kda/tests/test_kda.py
@@ -705,7 +705,7 @@ class Test_Flux_Calcs:
         G = nx.MultiDiGraph()
         graph_utils.generate_edges(G, K)
         # generate the directional partial diagrams
-        dirpar_edges = diagrams.generate_directional_partial_diagrams(
+        dirpar_edges = diagrams.generate_directional_diagrams(
             G, return_edges=True
         )
         # pick one of the 3-node cycles and the CCW direction
@@ -930,7 +930,7 @@ class Test_Diagram_Generation:
         assert len(partials) == expected_pars
         # generate the directional partial diagrams and verify
         # they agree with the expected value
-        dirpars = diagrams.generate_directional_partial_diagrams(G, return_edges=False)
+        dirpars = diagrams.generate_directional_diagrams(G, return_edges=False)
         assert len(dirpars) == expected_dirpars
         # count the number of partial diagrams
         # and verify they agree with the expected value
@@ -1005,7 +1005,7 @@ class Test_Diagram_Generation:
         assert len(partial_edges) == expected_pars
         # generate the directional partial diagrams and verify
         # they agree with the expected value
-        dirpar_edges = diagrams.generate_directional_partial_diagrams(
+        dirpar_edges = diagrams.generate_directional_diagrams(
             G, return_edges=True
         )
         expected_dirpars = n_states ** (n_states - 1)
@@ -1079,7 +1079,7 @@ def test_function_inputs():
     G = nx.MultiDiGraph()
     graph_utils.generate_edges(G, K)
     # generate the directional partial diagrams
-    dirpar_edges = diagrams.generate_directional_partial_diagrams(G, return_edges=True)
+    dirpar_edges = diagrams.generate_directional_diagrams(G, return_edges=True)
 
     # test both cases for calc_sigma()
     with pytest.raises(TypeError):


### PR DESCRIPTION
* Change name to `generate_directional_diagrams()`
and correct all function calls

* Simplify logic so code isn't so redundant

* Remove unnecessary graph creation for
`return_edges=True` case

* Switch to generating new graph object
instead of making copies of base graph