### PR TITLE
MAINT: Refactor `test_plotting.py`

### DIFF
--- a/kda/plotting.py
+++ b/kda/plotting.py
@@ -12,7 +12,7 @@ results from ODE solver.
 
 .. autofunction:: draw_diagrams
 .. autofunction:: draw_cycles
-.. autofunction:: draw_ODE_results
+.. autofunction:: draw_ode_results
 
 """
 
@@ -433,7 +433,7 @@ def draw_cycles(
                     plt.close()
 
 
-def draw_ODE_results(
+def draw_ode_results(
     results, figsize=(5, 4), legendloc="best", bbox_coords=None, path=None, label=None
 ):
     """


### PR DESCRIPTION
* Refactor all 3 testing functions, `test_draw_cycles`,
`test_draw_diagrams`, and `test_draw_ode_results`, to
use parametrization

* Change all 3 test functions to save the figure in a
temporary directory to increase code coverage and
close the figures

* Move flux diagram code for 4 state model with leakage
to its own function-scoped pytest fixture

* Simplify fixtures `G4wl`, `pos_4wl`, and `results_4wl`

* Remove unused imports

* Rename `draw_ODE_results` to `draw_ode_results`