### PR TITLE
MAINT, TST, ENH: Simplify flux diagram generation algo, update directional diagram algo to leverage `nx.all_simple_edge_paths()`

### DIFF
--- a/kda/diagrams.py
+++ b/kda/diagrams.py
@@ -200,12 +200,14 @@ def _construct_cycle_edges(cycle):
 
     Returns
     -------
-    reverse_list : list of tuples
+    cycle_edges : list of tuples
         List of edge tuples corresponding to the input cycle.
     """
-    reverse_list = list(zip(cycle[:-1], cycle[1:], np.zeros(len(cycle), dtype=int)))
-    reverse_list.append((cycle[-1], cycle[0], 0))
-    return reverse_list
+    # slice cycle to generate edge tuples using consecutive nodes
+    cycle_edges = list(zip(cycle[:-1], cycle[1:], np.zeros(len(cycle), dtype=int)))
+    # append tuple connecting first/last nodes in input cycle
+    cycle_edges.append((cycle[-1], cycle[0], 0))
+    return cycle_edges
 
 
 def _find_unique_uncommon_edges(G, cycle_edges):

--- a/kda/diagrams.py
+++ b/kda/diagrams.py
@@ -35,12 +35,11 @@ def _find_unique_edges(G):
     G : NetworkX MultiDiGraph
         Input diagram
     """
-    edges = list(G.edges)  # Get list of edges
-    sorted_edges = np.sort(edges)  # Sort list of edges
-    tuples = [
-        (sorted_edges[i, 1], sorted_edges[i, 2]) for i in range(len(sorted_edges))
-    ]  # Make list of edge tuples
-    return list(set(tuples))
+    # since non-directional graphs cannot contain forward/reverse edges,
+    # simply create a simple graph and collect its (unique) set of edges
+    G_temp = nx.Graph()
+    G_temp.add_edges_from(G.edges())
+    return list(G_temp.edges())
 
 
 def _combine(x, y):

--- a/kda/diagrams.py
+++ b/kda/diagrams.py
@@ -492,9 +492,7 @@ def generate_flux_diagrams(G, cycle):
             if cons:
                 # if there are directional connections, generate and
                 # store the directional edges
-                dir_edges.append(_get_directional_edges(cons))
-        # flatten the nested lists of edges
-        dir_edges = [edge for edges in dir_edges for edge in edges]
+                dir_edges.extend(_get_directional_edges(cons))
         if _flux_edge_conditions(dir_edges, n_non_cycle_edges):
             # make a copy of the base graph
             flux_diag = base_graph.copy()

--- a/kda/diagrams.py
+++ b/kda/diagrams.py
@@ -397,7 +397,6 @@ def generate_directional_diagrams(G, return_edges=False):
     """
     partial_diagram_edges = generate_partial_diagrams(G, return_edges=True)
 
-    base_nodes = G.nodes()
     n_states = G.number_of_nodes()
     n_partials = len(partial_diagram_edges)
     n_dir_diags = n_states * n_partials
@@ -418,7 +417,6 @@ def generate_directional_diagrams(G, return_edges=False):
                 directional_diagrams[j + i*n_partials] = dir_edges
             else:
                 directional_diagram = nx.MultiDiGraph()
-                directional_diagram.add_nodes_from(base_nodes)
                 directional_diagram.add_edges_from(dir_edges)
                 # set "is_target" to False for all nodes
                 nx.set_node_attributes(directional_diagram, False, "is_target")
@@ -488,18 +486,13 @@ def generate_flux_diagrams(G, cycle):
             dir_edges.extend(cycle_edges)
             # add all edges to flux diagram
             flux_diag.add_edges_from(dir_edges)
-            # collect all nodes in the potential flux
-            # diagram from the diagram edges
-            included_nodes = np.unique(flux_diag.edges)
             # if the diagram contains all nodes it is still valid
-            if included_nodes.size == G.number_of_nodes():
+            if flux_diag.number_of_nodes() == G.number_of_nodes():
                 # count how many cycles are in the flux diagram by removing
                 # 2-node cycles
                 # NetworkX stores forward/reverse cycles, so if 2 remain there
                 # is 1 unique cycle for this flux diagram
-                contains_1_cycle = (
-                    len([c for c in nx.simple_cycles(flux_diag) if len(c) > 2]) == 2
-                )
+                contains_1_cycle = len([c for c in nx.simple_cycles(flux_diag) if len(c) > 2]) == 2
                 # if there is exactly 1 unique cycle in the
                 # generated diagram, it is valid
                 if contains_1_cycle:

--- a/kda/tests/test_kda.py
+++ b/kda/tests/test_kda.py
@@ -642,7 +642,7 @@ class Test_Probability_Calcs:
         assert_almost_equal(ode_probs, expected_probs, decimal=10)
 
 
-class Test_Flux_Calcs:
+class Test_Flux_Diagrams:
     def test_generate_all_flux_diags(self):
         # Test just to verify that generating all flux diagrams returns the
         # same result as generating them one at a time
@@ -878,6 +878,25 @@ class Test_Flux_Calcs:
                 # book, and total to 37 (not including the all-node cycle g)
                 6,
                 37,
+            ),
+            (
+                # 8-state model
+                [
+                    [0, 1, 1, 0, 0, 0, 1, 0],
+                    [1, 0, 0, 1, 0, 0, 0, 1],
+                    [1, 0, 0, 1, 1, 0, 0, 0],
+                    [0, 1, 1, 0, 0, 1, 0, 0],
+                    [0, 0, 1, 0, 0, 1, 1, 0],
+                    [0, 0, 0, 1, 1, 0, 0, 1],
+                    [1, 0, 0, 0, 1, 0, 0, 1],
+                    [0, 1, 0, 0, 0, 1, 1, 0],
+                ],
+                # model has 28 unique cycles with a total of 402 flux diagrams.
+                # this model is unique because it has many cycles that contain
+                # all nodes and thus do not have any flux diagrams associated
+                # with them.
+                28,
+                402,
             ),
         ],
     )

--- a/kda/tests/test_kda.py
+++ b/kda/tests/test_kda.py
@@ -916,7 +916,19 @@ class Test_Flux_Diagrams:
         for cycle in all_cycles:
             flux_diagrams = diagrams.generate_flux_diagrams(G, cycle)
             if flux_diagrams:
-                actual_flux_diag_count += len(flux_diagrams)
+                for flux_diag in flux_diagrams:
+                    # check that flux diagrams have the same nodes
+                    # as the input diagram
+                    assert sorted(flux_diag.nodes()) == sorted(G.nodes())
+                    # collect the cycles in the flux diagram, excluding the
+                    # simplest 2-node cycles
+                    cycles = [c for c in nx.simple_cycles(flux_diag) if len(c) > 2]
+                    # check that there are only 2 cycles, which should be the
+                    # same cycle just in the forward/reverse directions
+                    assert len(cycles) == 2
+                    # check that the forward/reverse cycles are the same
+                    assert sorted(cycles[0]) == sorted(cycles[1])
+                    actual_flux_diag_count += 1
 
         assert actual_flux_diag_count == expected_flux_diag_count
 


### PR DESCRIPTION
* Simplify `_append_reverse_edges()`, `_get_directional_edges()` and
`_flux_edge_conditions()`

* Simplify `_find_unique_edges()`. Performance comparisons
using %timeit showed slight improvement with new algo

* Simplify `_find_unique_uncommon_edges()` and change call
signature such that it takes a graph object and the list
of forward and reverse cycle edges

* Multiple simplifications for `generate_flux_diagrams()`:
  - Generate fresh diagrams instead of making copies
    of a base diagram. This was demonstrated to be
    faster for directional diagram generation.
  - Remove unnecessary `add_nodes_from()` call
  - Simplify node counting
  - Correct call signature for `_find_unique_uncommon_edges()`

* Rename `Test_Flux_Calcs` to `Test_Flux_Diagrams`

* Add 8-state model test case to `test_flux_diagram_counts()`

* Rename `_get_directional_path_edges()` to
`_get_flux_path_edges()` since it is now used
only for flux diagram generation

* Add functions `_collect_sources()` and
`_get_directional_path_edges()` which now
handle the spanning tree pathway finding
for `generate_directional_diagrams()`

* Change `generate_directional_diagrams()`
to use actual diagram objects for generating
the directional diagrams, as is required for
leveraging the NetworkX built-in path finding
function `all_simple_edge_paths()`