### PR TITLE
MAINT: Fix future deprecation warning

### DIFF
--- a/kda/diagrams.py
+++ b/kda/diagrams.py
@@ -303,7 +303,7 @@ def _get_cofactor_matrix(K_laplace):
     N = len(w)
     g = np.tile(w, N)
     g[:: (N + 1)] = 1
-    G = np.diag(-((-1) ** N) * np.product(np.reshape(g, (N, N)), 1))
+    G = np.diag(-((-1) ** N) * np.prod(np.reshape(g, (N, N)), 1))
     K_cof = U @ G @ Vt
     K_cof = np.asarray(np.round(K_cof, decimals=0), dtype=int)
     return K_cof


### PR DESCRIPTION
## Description

* Fixes issue #72

* Fix future deprecation warning by replacing instance of `np.product()` with `np.prod()`
in `diagrams._get_cofactor_matrix()`