### PR TITLE
CI, TST, MAINT: Fix HealthCheck error, update CI Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/kda/tests/test_kda.py
+++ b/kda/tests/test_kda.py
@@ -7,7 +7,7 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_allclose, assert_array_equal
-from hypothesis import settings, given, strategies as st
+from hypothesis import settings, given, strategies as st, HealthCheck
 import networkx as nx
 
 from kda import calculations, diagrams, graph_utils, expressions, ode, svd
@@ -970,6 +970,7 @@ class Test_Misc_Funcs:
         assert sigma_K_func == expected_func
 
     @settings(deadline=None)
+    @settings(suppress_health_check=[HealthCheck.differing_executors])
     @given(
         k_vals=st.lists(
             st.floats(min_value=1, max_value=100), min_size=10, max_size=10

--- a/kda/tests/test_kda.py
+++ b/kda/tests/test_kda.py
@@ -969,8 +969,7 @@ class Test_Misc_Funcs:
         expected_func = "k32+k34"
         assert sigma_K_func == expected_func
 
-    @settings(deadline=None)
-    @settings(suppress_health_check=[HealthCheck.differing_executors])
+    @settings(deadline=None, suppress_health_check=[HealthCheck.differing_executors])
     @given(
         k_vals=st.lists(
             st.floats(min_value=1, max_value=100), min_size=10, max_size=10


### PR DESCRIPTION
## Description

* Remove `HealthCheck.differing_executors` error for `test_thermo_force_4WL`

* Fixes #76

* Fixes #77

## Status
- [x] Ready to go