### PR TITLE
WIP, API: Add simple API for KDA

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ K = np.array(
 )
 # create a KineticModel from the rate matrix
 model = kda.KineticModel(K=K, G=None)
-# calculate the state probabilities
+# get the state probabilities in numeric form
 model.build_state_probabilities(symbolic=False)
 print("State probabilities: \n", model.probabilities)
 # get the state probabilities in expression form
@@ -39,7 +39,7 @@ print("State 1 probability expression: \n", model.probabilities[0])
 
 The output from the above example:
 ```bash
-$ python example_script.py
+$ python example.py
 State probabilities:
  [0.33333333 0.33333333 0.33333333]
 State 1 probability expression:
@@ -48,12 +48,35 @@ State 1 probability expression:
 ```
 As expected, the state probabilities are equal because all edge weights are set to a value of 1.
 
+Additionally, the transition fluxes (one-way or net) can be calculated from the `KineticModel`:
+```python
+# make sure the symbolic probabilities have been generated
+model.build_state_probabilities(symbolic=True)
+# iterate over all edges
+print("One-way transition fluxes:")
+for (i, j) in model.G.edges():
+    flux = model.get_transition_flux(state_i=i+1, state_j=j+1, net=False, symbolic=True)
+    print(f"j_{i+1}{j+1} = {flux}")
+```
+
+The output from the above example:
+```bash
+$ python example.py
+One-way transition fluxes:
+j_12 = (k12*k21*k31 + k12*k21*k32 + k12*k23*k31)/(k12*k23 + k12*k31 + k12*k32 + k13*k21 + k13*k23 + k13*k32 + k21*k31 + k21*k32 + k23*k31)
+j_13 = (k13*k21*k31 + k13*k21*k32 + k13*k23*k31)/(k12*k23 + k12*k31 + k12*k32 + k13*k21 + k13*k23 + k13*k32 + k21*k31 + k21*k32 + k23*k31)
+j_21 = (k12*k21*k31 + k12*k21*k32 + k13*k21*k32)/(k12*k23 + k12*k31 + k12*k32 + k13*k21 + k13*k23 + k13*k32 + k21*k31 + k21*k32 + k23*k31)
+j_23 = (k12*k23*k31 + k12*k23*k32 + k13*k23*k32)/(k12*k23 + k12*k31 + k12*k32 + k13*k21 + k13*k23 + k13*k32 + k21*k31 + k21*k32 + k23*k31)
+j_31 = (k12*k23*k31 + k13*k21*k31 + k13*k23*k31)/(k12*k23 + k12*k31 + k12*k32 + k13*k21 + k13*k23 + k13*k32 + k21*k31 + k21*k32 + k23*k31)
+j_32 = (k12*k23*k32 + k13*k21*k32 + k13*k23*k32)/(k12*k23 + k12*k31 + k12*k32 + k13*k21 + k13*k23 + k13*k32 + k21*k31 + k21*k32 + k23*k31)
+```
+
 Continuing with the previous example, the KDA `plotting` module can be leveraged to display the diagrams that lead to the above probability expression:
 ```python
 import os
 from kda import plotting
 
-# generate the set of directional diagrams for G
+# generate the directional diagrams
 model.build_directional_diagrams()
 # get the current working directory
 cwd = os.getcwd()
@@ -76,7 +99,7 @@ This will generate two files, `input.png` and `directional_panel.png`, in your c
 #### `input.png`
 <img src="https://github.com/Becksteinlab/kda-examples/blob/master/kda_examples/test_model_3_state/diagrams/input.png" width=300, alt="3-state model input diagram">
 
-#### `directional.png`
+#### `directional_panel.png`
 <img src="https://github.com/Becksteinlab/kda-examples/blob/master/kda_examples/test_model_3_state/diagrams/directional.png" width=300, alt="3-state model directional diagrams">
 
 **NOTE:** For more examples (like the following) visit the [KDA examples](https://github.com/Becksteinlab/kda-examples) repository:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,6 +4,7 @@ API Documentation
 .. autosummary::
    :toctree: autosummary
 
+   kda.core
    kda.calculations
    kda.diagrams
    kda.expressions

--- a/docs/autosummary/kda.core.rst
+++ b/docs/autosummary/kda.core.rst
@@ -1,0 +1,29 @@
+﻿kda.core
+========
+
+.. automodule:: kda.core
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      KineticModel
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -34,41 +34,65 @@ The following is an example for a simple 3-state model with all nodes connected:
 
 .. code-block:: python
 
-	import numpy as np
-	import networkx as nx
-	from kda import graph_utils, calculations
+  import numpy as np
+  import kda
 
-	# define matrix with reaction rates set to 1
-	K = np.array(
-	    [
-	        [0, 1, 1],
-	        [1, 0, 1],
-	        [1, 1, 0],
-	    ]
-	)
-	# initialize an empty graph object
-	G = nx.MultiDiGraph()
-	# populate the edge data
-	graph_utils.generate_edges(G, K, val_key="val", name_key="name")
-	# calculate the state probabilities
-	state_probabilities = calculations.calc_state_probs(G, key="val")
-	# get the state probabilities in expression form
-	state_probability_str = calculations.calc_state_probs(G, key="name", output_strings=True)
-	# print results
-	print("State probabilities: \n", state_probabilities)
-	print("State 1 probability expression: \n", state_probability_str[0])
+  # define matrix with reaction rates set to 1
+  K = np.array(
+      [
+          [0, 1, 1],
+          [1, 0, 1],
+          [1, 1, 0],
+      ]
+  )
+  # create a KineticModel from the rate matrix
+  model = kda.KineticModel(K=K, G=None)
+  # get the state probabilities in numeric form
+  model.build_state_probabilities(symbolic=False)
+  print("State probabilities: \n", model.probabilities)
+  # get the state probabilities in expression form
+  model.build_state_probabilities(symbolic=True)
+  print("State 1 probability expression: \n", model.probabilities[0])
 
 The output from the above example:
 
 .. code-block:: console
 
-	$ python example_script.py
-	State probabilities:
-	 [0.33333333 0.33333333 0.33333333]
-	State 1 probability expression:
-	 (k21*k31 + k21*k32 + k23*k31)/(k12*k23 + k12*k31 + k12*k32 + k13*k21 + k13*k23 + k13*k32 + k21*k31 + k21*k32 + k23*k31)
+  $ python example.py
+  State probabilities:
+   [0.33333333 0.33333333 0.33333333]
+  State 1 probability expression:
+   (k21*k31 + k21*k32 + k23*k31)/(k12*k23 + k12*k31 + k12*k32 + k13*k21 + k13*k23 + k13*k32 + k21*k31 + k21*k32 + k23*k31)
 
 As expected, the state probabilities are equal because all edge weights are set to a value of 1.
+
+Calculating Transition Fluxes
+-----------------------------
+Continuing with the previous example, the transition fluxes (one-way or net) can be calculated from the :class:`~kda.core.KineticModel`:
+
+.. code-block:: python
+
+  # make sure the symbolic probabilities have been generated
+  model.build_state_probabilities(symbolic=True)
+  # iterate over all edges
+  print("One-way transition fluxes:")
+  for (i, j) in model.G.edges():
+      flux = model.get_transition_flux(state_i=i+1, state_j=j+1, net=False, symbolic=True)
+      print(f"j_{i+1}{j+1} = {flux}")
+
+The output from the above example:
+
+.. code-block:: console
+
+  $ python example.py
+  One-way transition fluxes:
+  j_12 = (k12*k21*k31 + k12*k21*k32 + k12*k23*k31)/(k12*k23 + k12*k31 + k12*k32 + k13*k21 + k13*k23 + k13*k32 + k21*k31 + k21*k32 + k23*k31)
+  j_13 = (k13*k21*k31 + k13*k21*k32 + k13*k23*k31)/(k12*k23 + k12*k31 + k12*k32 + k13*k21 + k13*k23 + k13*k32 + k21*k31 + k21*k32 + k23*k31)
+  j_21 = (k12*k21*k31 + k12*k21*k32 + k13*k21*k32)/(k12*k23 + k12*k31 + k12*k32 + k13*k21 + k13*k23 + k13*k32 + k21*k31 + k21*k32 + k23*k31)
+  j_23 = (k12*k23*k31 + k12*k23*k32 + k13*k23*k32)/(k12*k23 + k12*k31 + k12*k32 + k13*k21 + k13*k23 + k13*k32 + k21*k31 + k21*k32 + k23*k31)
+  j_31 = (k12*k23*k31 + k13*k21*k31 + k13*k23*k31)/(k12*k23 + k12*k31 + k12*k32 + k13*k21 + k13*k23 + k13*k32 + k21*k31 + k21*k32 + k23*k31)
+  j_32 = (k12*k23*k32 + k13*k21*k32 + k13*k23*k32)/(k12*k23 + k12*k31 + k12*k32 + k13*k21 + k13*k23 + k13*k32 + k21*k31 + k21*k32 + k23*k31)
+
 
 Displaying Diagrams
 -------------------
@@ -77,25 +101,25 @@ Continuing with the previous example, the KDA ``diagrams`` and ``plotting`` modu
 
 .. code-block:: python
 
-	import os
-	from kda import diagrams, plotting
+  import os
+  from kda import plotting
 
-	# generate the set of directional diagrams for G
-	directional_diagrams = diagrams.generate_directional_diagrams(G)
-	# get the current working directory
-	cwd = os.getcwd()
-	# specify the positions of all nodes in NetworkX fashion
-	node_positions = {0: [0, 1], 1: [-0.5, 0], 2: [0.5, 0]}
-	# plot and save the input diagram
-	plotting.draw_diagrams(G, pos=node_positions, path=cwd, label="input")
-	# plot and save the directional diagrams as a panel
-	plotting.draw_diagrams(
-	    directional_diagrams,
-	    pos=node_positions,
-	    path=cwd,
-	    cbt=True,
-	    label="directional_panel",
-	)
+  # generate the directional diagrams
+  model.build_directional_diagrams()
+  # get the current working directory
+  cwd = os.getcwd()
+  # specify the positions of all nodes in NetworkX fashion
+  node_positions = {0: [0, 1], 1: [-0.5, 0], 2: [0.5, 0]}
+  # plot and save the input diagram
+  plotting.draw_diagrams(model.G, pos=node_positions, path=cwd, label="input")
+  # plot and save the directional diagrams as a panel
+  plotting.draw_diagrams(
+    model.directional_diagrams,
+    pos=node_positions,
+    path=cwd,
+    cbt=True,
+    label="directional_panel",
+  )
 
 This will generate two files, ``input.png`` and ``directional_panel.png``, in your current working directory:
 
@@ -103,7 +127,7 @@ This will generate two files, ``input.png`` and ``directional_panel.png``, in yo
 
 |img_3_input|
 
-**directional.png**
+**directional_panel.png**
 
 |img_3_directional|
 

--- a/kda/__init__.py
+++ b/kda/__init__.py
@@ -10,6 +10,7 @@ Python package used for the analysis of biochemical kinetic diagrams.
 """
 
 # Add imports here
+from .core import KineticModel
 
 # Handle versioneer
 from ._version import get_versions

--- a/kda/__init__.py
+++ b/kda/__init__.py
@@ -4,9 +4,24 @@
 # Author: Nikolaus C. Awtrey
 #
 """
-Kinetic Diagram Analysis (kda)
+Core functions of Kinetic Diagram Analysis
 =========================================================================
-Python package used for the analysis of biochemical kinetic diagrams.
+
+The core class is a :class:`~kda.core.KineticModel` which contains
+all the system information (kinetic diagram, transition rates, etc.).
+
+To get started, load the KineticModel::
+
+  model = KineticModel(K=rate_matrix, G=nx.MultiDiGraph)
+
+With the model created the state probability expressions can be
+generated using the built-in methods::
+
+  model.build_state_probabilities(symbolic=True)
+
+Other methods are available to generate the various graphs or
+calculate fluxes.
+
 """
 
 # Add imports here

--- a/kda/core.py
+++ b/kda/core.py
@@ -68,7 +68,7 @@ class KineticModel(object):
 			if K is not None:
 				# if only K is input create the diagram
 				G = nx.MultiDiGraph()
-				graph_utils.generate_edges(G=G, K=K)
+				graph_utils.generate_edges(G=G, vals=K)
 			elif G is not None:
 				# if only G is input create the kinetic rate matrix
 				K = graph_utils.retrieve_rate_matrix(G)
@@ -170,8 +170,16 @@ class KineticModel(object):
 		# TODO: may be able to leverage `calc_state_probs_from_diags()`
 		# here, but it would require the user has already generated the
 		# directional diagrams as edges, which is probably atypical
+		# NOTE: currently hacking in the `key` parameters here
+		# assuming the edge attributes follow the name/val convention.
+		# eventually all calculation functions should be sophisticated
+		# enough where only `symbolic=True` is sufficient
+		if symbolic:
+			key = "name"
+		else:
+			key = "val"
 		self.probabilities = calculations.calc_state_probs(
-			self.G, output_strings=symbolic)
+			self.G, key=key, output_strings=symbolic)
 
 
 	def get_transition_flux(self, state_i, state_j, net=True, symbolic=True):

--- a/kda/core.py
+++ b/kda/core.py
@@ -99,7 +99,7 @@ class KineticModel(object):
 		Net transition flux: J_ij = j_ij - j_ji
 		"""
 		if i == j:
-			msg = "Input indices must not be unique (i.e. i != j)."
+			msg = "Input indices must be unique (i.e. i != j)."
 			raise ValueError(msg)
 
 		if self.probabilities is None:
@@ -110,9 +110,9 @@ class KineticModel(object):
 			# requested transition flux type (numeric vs symbolic)
 			is_symbolic = isinstance(self.probabilities[0], Mul)
 			if symbolic != is_symbolic:
-				msg = f"""`KineticModel.probabilities` are the incorrect
-				type for the requested transition flux type. Regenerate
-				probabilities with `symbolic={symbolic}` before continuing."""
+				msg = f"`KineticModel.probabilities` are the incorrect type for the"
+					f" requested transition flux type. Regenerate probabilities"
+					f" with `symbolic={symbolic}` before continuing."
 				raise TypeError(msg)
 
 		if symbolic:

--- a/kda/core.py
+++ b/kda/core.py
@@ -110,9 +110,11 @@ class KineticModel(object):
 			# requested transition flux type (numeric vs symbolic)
 			is_symbolic = isinstance(self.probabilities[0], Mul)
 			if symbolic != is_symbolic:
-				msg = f"`KineticModel.probabilities` are the incorrect type for the"
+				msg = (
+					f"`KineticModel.probabilities` are the incorrect type for the"
 					f" requested transition flux type. Regenerate probabilities"
 					f" with `symbolic={symbolic}` before continuing."
+				)
 				raise TypeError(msg)
 
 		if symbolic:

--- a/kda/core.py
+++ b/kda/core.py
@@ -241,8 +241,7 @@ class KineticModel(object):
 
 		Returns
 		=======
-		The transition flux (either one-way or net) from state ``i`` to
-		state ``j``.
+		The transition flux (one-way or net) from state ``i`` to state ``j``.
 
 		Raises
 		======

--- a/kda/core.py
+++ b/kda/core.py
@@ -1,0 +1,133 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+#
+# Author: Nikolaus C. Awtrey
+#
+"""
+Kinetic Diagram Analysis: Core
+=========================================================================
+The :class:`~kda.core.KineticModel` class contains all the information
+for a kinetic model.
+"""
+
+import networkx as nx
+from sympy import symbols, Mul
+
+from kda import graph_utils, diagrams, calculations
+
+
+class KineticModel(object):
+	"""
+	Kinetic Model
+	"""
+
+	def __init__(self, K=None, G=None):
+		if G is None or K is None:
+			if K is not None:
+				# if only K is input create the diagram
+				G = nx.MultiDiGraph()
+				# TODO: remove the need for the val/name keys (see issue #56)
+				graph_utils.generate_edges(G, vals=K, names=None, val_key="val")
+			elif G is not None:
+				# if only G is input create the kinetic rate matrix
+				# TODO: remove the need for the val/name keys (see issue #56)
+				K = graph_utils.retrieve_rate_matrix(G, key="val")
+			else:
+				msg = "To create a `KineticModel`, K or G must be input."
+				raise RuntimeError(msg)
+
+		self.K = K
+		self.G = G
+
+		# assign None for future attributes
+		self.cycles = None
+		self.partial_diagrams = None
+		self.directional_diagrams = None
+		self.flux_diagrams = None
+		self.probabilities = None
+
+
+	def build_cycles(self):
+		self.cycles = graph_utils.find_all_unique_cycles(self.G)
+
+
+	def build_partial_diagrams(self):
+		self.partial_diagrams = diagrams.generate_partial_diagrams(self.G, return_edges=False)
+
+
+	def build_directional_diagrams(self):
+		self.directional_diagrams = diagrams.generate_directional_diagrams(self.G, return_edges=False)
+
+
+	def build_flux_diagrams(self):
+		self.flux_diagrams = diagrams.generate_all_flux_diagrams(self.G)
+
+
+	def get_partial_diagram_count(self):
+		if self.partial_diagrams is not None:
+			return len(self.partial_diagrams)
+		else:
+			return diagrams.enumerate_partial_diagrams(self.G)
+
+
+	def get_directional_diagram_count(self):
+		if self.directional_diagrams is not None:
+			return len(self.directional_diagrams)
+		else:
+			partial_count = self.get_partial_diagram_count()
+			return self.G.number_of_nodes() * partial_count
+
+
+	def get_flux_diagrams(self, cycle):
+		return diagrams.generate_flux_diagrams(self.G, cycle)
+
+
+	def build_state_probabilities(self, symbolic=True):
+		if symbolic:
+			key = "name"
+		else:
+			key = "val"
+		# TODO: may be able to leverage `calc_state_probs_from_diags()`
+		# here, but it would require the user has already generated the
+		# directional diagrams as edges, which is probably atypical
+		self.probabilities = calculations.calc_state_probs(self.G, key=key, output_strings=symbolic)
+
+
+	def transition_flux(self, i, j, net=True, symbolic=True):
+		"""
+		One-way transition flux: j_ij = k_ij * p_i
+		Net transition flux: J_ij = j_ij - j_ji
+		"""
+		if i == j:
+			msg = "Input indices must not be unique (i.e. i != j)."
+			raise ValueError(msg)
+
+		if self.probabilities is None:
+			print(f"No probabilities found, generating state probabilities with symbolic={symbolic}")
+			self.build_state_probabilities(symbolic=symbolic)
+		else:
+			# check if stored probability data type matches the
+			# requested transition flux type (numeric vs symbolic)
+			is_symbolic = isinstance(self.probabilities[0], Mul)
+			if symbolic != is_symbolic:
+				msg = f"""`KineticModel.probabilities` are the incorrect
+				type for the requested transition flux type. Regenerate
+				probabilities with `symbolic={symbolic}` before continuing."""
+				raise TypeError(msg)
+
+		if symbolic:
+			# symbolic case
+			j_ij = symbols(f"k{i}{j}") * self.probabilities[i-1]
+			if not net:
+				return j_ij.cancel()
+			else:
+				j_ji = symbols(f"k{j}{i}") * self.probabilities[j-1]
+				return (j_ij - j_ji).cancel()
+		else:
+			# numerical case
+			j_ij = self.K[i-1][j-1] * self.probabilities[i-1]
+			if not net:
+				return j_ij
+			else:
+				j_ji = self.K[j-1][i-1] * self.probabilities[j-1]
+				return j_ij - j_ji

--- a/kda/core.py
+++ b/kda/core.py
@@ -26,12 +26,10 @@ class KineticModel(object):
 			if K is not None:
 				# if only K is input create the diagram
 				G = nx.MultiDiGraph()
-				# TODO: remove the need for the val/name keys (see issue #56)
-				graph_utils.generate_edges(G, vals=K, names=None, val_key="val")
+				graph_utils.generate_edges(G=G, K=K)
 			elif G is not None:
 				# if only G is input create the kinetic rate matrix
-				# TODO: remove the need for the val/name keys (see issue #56)
-				K = graph_utils.retrieve_rate_matrix(G, key="val")
+				K = graph_utils.retrieve_rate_matrix(G)
 			else:
 				msg = "To create a `KineticModel`, K or G must be input."
 				raise RuntimeError(msg)
@@ -83,14 +81,10 @@ class KineticModel(object):
 
 
 	def build_state_probabilities(self, symbolic=True):
-		if symbolic:
-			key = "name"
-		else:
-			key = "val"
 		# TODO: may be able to leverage `calc_state_probs_from_diags()`
 		# here, but it would require the user has already generated the
 		# directional diagrams as edges, which is probably atypical
-		self.probabilities = calculations.calc_state_probs(self.G, key=key, output_strings=symbolic)
+		self.probabilities = calculations.calc_state_probs(self.G, output_strings=symbolic)
 
 
 	def transition_flux(self, i, j, net=True, symbolic=True):

--- a/kda/core.py
+++ b/kda/core.py
@@ -18,10 +18,51 @@ from kda import graph_utils, diagrams, calculations
 
 class KineticModel(object):
 	"""
-	Kinetic Model
+	Core `kda` object that constructs the kinetic diagram,
+	generates the intermediate graphs, and builds the algebraic
+	expressions for steady-state probabilities and fluxes.
+
+	Attributes
+	==========
+	cycles : list of lists of int
+		All cycles in the kinetic diagram. This attribute becomes
+		available after running the `build_cycles` method.
+    partial_diagrams : array of Networkx Graphs
+        The set of partial diagrams (i.e. spanning trees) for the
+        kinetic diagram. This attribute becomes available after
+        running the `build_partial_diagrams` method.
+    directional_diagrams : array of Networkx MultiDiGraphs
+        The set of directional diagrams for the kinetic diagram.
+        This attribute becomes available after running the
+        `build_directional_diagrams` method.
+	flux_diagrams : list of lists of Networkx MultiDiGraphs
+        The set of flux diagrams for each cycle in the kinetic
+        diagram. This attribute becomes available after running
+        the `build_flux_diagrams` method.
+	probabilities : array of floats or list of SymPy expressions
+		The steady-state probabilities for all states in the kinetic
+		diagram. Probabilities are either an array of numeric values
+		or the algebraic expressions. This attribute becomes available
+		after running the `build_state_probabilities` method.
 	"""
 
 	def __init__(self, K=None, G=None):
+		"""
+		Parameters
+		==========
+	    K : ndarray (optional)
+	        'NxN' array where 'N' is the number of nodes in the diagram `G`.
+	        Adjacency matrix for `G` where each element kij is the edge weight
+	        (i.e. transition rate constant). For example, for a 2-state model
+	        with `k12=3` and `k21=4`, `K=[[0, 3], [4, 0]]`. Default is `None`.
+	    G : NetworkX MultiDiGraph (optional)
+	        Input diagram. Default is `None`.
+
+		Raises
+	    ======
+	    RuntimeError
+	    	If both `K` and `G` are `None`.
+		"""
 		if G is None or K is None:
 			if K is not None:
 				# if only K is input create the diagram
@@ -46,22 +87,34 @@ class KineticModel(object):
 
 
 	def build_cycles(self):
+		"""Builds all cycles from the kinetic diagram."""
 		self.cycles = graph_utils.find_all_unique_cycles(self.G)
 
 
 	def build_partial_diagrams(self):
+		"""Builds the partial diagrams for the kinetic diagram."""
 		self.partial_diagrams = diagrams.generate_partial_diagrams(self.G, return_edges=False)
 
 
 	def build_directional_diagrams(self):
+		"""Builds the directional diagrams for the kinetic diagram."""
 		self.directional_diagrams = diagrams.generate_directional_diagrams(self.G, return_edges=False)
 
 
 	def build_flux_diagrams(self):
+		"""Builds the flux diagrams for the kinetic diagram."""
 		self.flux_diagrams = diagrams.generate_all_flux_diagrams(self.G)
 
 
 	def get_partial_diagram_count(self):
+		"""
+		Retrieves the number of partial diagrams that will
+		be created from the kinetic diagram.
+
+		Returns
+		=======
+		The integer number of partial diagrams.
+		"""
 		if self.partial_diagrams is not None:
 			return len(self.partial_diagrams)
 		else:
@@ -69,6 +122,14 @@ class KineticModel(object):
 
 
 	def get_directional_diagram_count(self):
+		"""
+		Retrieves the number of directional diagrams that will
+		be created from the kinetic diagram.
+
+		Returns
+		=======
+		The integer number of directional diagrams.
+		"""
 		if self.directional_diagrams is not None:
 			return len(self.directional_diagrams)
 		else:
@@ -77,20 +138,73 @@ class KineticModel(object):
 
 
 	def get_flux_diagrams(self, cycle):
+		"""
+		Retrieves the flux diagrams for a specific cycle.
+
+		Parameters
+		==========
+	    cycle : list of int
+	        List of node indices for cycle of interest, index zero.
+	        Order of node indices does not matter.
+
+		Returns
+		=======
+		The flux diagrams associated with the input cycle.
+		"""
 		return diagrams.generate_flux_diagrams(self.G, cycle)
 
 
 	def build_state_probabilities(self, symbolic=True):
+		"""
+		Builds the state probabilities for the kinetic diagram. Probabilities
+		can be stored as raw values or symbolic algebraic expressions.
+
+		Parameters
+		==========
+	    symbolic : bool (optional)
+	        Used to determine whether raw values or symbolic
+	        expressions will be stored. Default is True.
+		"""
 		# TODO: may be able to leverage `calc_state_probs_from_diags()`
 		# here, but it would require the user has already generated the
 		# directional diagrams as edges, which is probably atypical
-		self.probabilities = calculations.calc_state_probs(self.G, output_strings=symbolic)
+		self.probabilities = calculations.calc_state_probs(
+			self.G, output_strings=symbolic)
 
 
 	def transition_flux(self, i, j, net=True, symbolic=True):
 		"""
-		One-way transition flux: j_ij = k_ij * p_i
-		Net transition flux: J_ij = j_ij - j_ji
+		Creates the one-way or net transition fluxes.
+
+		Parameters
+		==========
+		i : integer
+			The index of the initial state for calculating
+			transition fluxes.
+		j : integer
+			The index of the final state for calculating
+			transition fluxes.
+		net : bool (optional)
+			Used to determine whether one-way transition fluxes
+			or net transition fluxes will be returned. Default
+			is True.
+	    symbolic : bool (optional)
+	        Used to determine whether raw values or symbolic
+	        expressions will be returned. Default is True.
+
+		Returns
+		=======
+		The transition flux (either one-way or net) from
+		state `i` to state `j`.
+
+	    Raises
+	    ======
+	    ValueError
+	    	If the input states are the same (i.e. `i==j`).
+	    TypeError
+	    	If the stored state probability type (symbolic or numeric)
+	    	is a differnt type than the requested transition
+	    	flux type.
 		"""
 		if i == j:
 			msg = "Input indices must be unique (i.e. i != j)."
@@ -113,17 +227,21 @@ class KineticModel(object):
 
 		if symbolic:
 			# symbolic case
+			# One-way transition flux: j_ij = k_ij * p_i
 			j_ij = symbols(f"k{i}{j}") * self.probabilities[i-1]
 			if not net:
 				return j_ij.cancel()
 			else:
+				# Net transition flux: J_ij = j_ij - j_ji
 				j_ji = symbols(f"k{j}{i}") * self.probabilities[j-1]
 				return (j_ij - j_ji).cancel()
 		else:
 			# numerical case
+			# One-way transition flux: j_ij = k_ij * p_i
 			j_ij = self.K[i-1][j-1] * self.probabilities[i-1]
 			if not net:
 				return j_ij
 			else:
+				# Net transition flux: J_ij = j_ij - j_ji
 				j_ji = self.K[j-1][i-1] * self.probabilities[j-1]
 				return j_ij - j_ji

--- a/kda/core.py
+++ b/kda/core.py
@@ -4,10 +4,20 @@
 # Author: Nikolaus C. Awtrey
 #
 """
-Kinetic Diagram Analysis: Core
+Core
 ======================================================================
 The :class:`~kda.core.KineticModel` class contains all the information
 for a kinetic model.
+
+Classes
+=======
+
+.. autoclass:: KineticModel
+   :members:
+
+References
+==========
+.. footbibliography::
 """
 
 import networkx as nx
@@ -27,42 +37,47 @@ class KineticModel(object):
 	==========
 	cycles : list of lists of int
 		All cycles in the kinetic diagram. This attribute becomes
-		available after running the `build_cycles` method.
-    partial_diagrams : array of Networkx Graphs
-        The set of partial diagrams (i.e. spanning trees) for the
-        kinetic diagram. This attribute becomes available after
-        running the `build_partial_diagrams` method.
-    directional_diagrams : array of Networkx MultiDiGraphs
-        The set of directional diagrams for the kinetic diagram.
-        This attribute becomes available after running the
-        `build_directional_diagrams` method.
+		available after running the
+		:meth:`~kda.core.KineticModel.build_cycles` method.
+	partial_diagrams : array of Networkx Graphs
+		The set of partial diagrams (i.e. spanning trees) for the
+		kinetic diagram. This attribute becomes available after
+		running the :meth:`~kda.core.KineticModel.build_partial_diagrams`
+		method.
+	directional_diagrams : array of Networkx MultiDiGraphs
+		The set of directional diagrams for the kinetic diagram.
+		This attribute becomes available after running the
+		:meth:`~kda.core.KineticModel.build_directional_diagrams` method.
 	flux_diagrams : list of lists of Networkx MultiDiGraphs
-        The set of flux diagrams for each cycle in the kinetic
-        diagram. This attribute becomes available after running
-        the `build_flux_diagrams` method.
+		The set of flux diagrams for each cycle in the kinetic
+		diagram. This attribute becomes available after running
+		the :meth:`~kda.core.KineticModel.build_flux_diagrams` method.
 	probabilities : array of floats or list of SymPy expressions
 		The steady-state probabilities for all states in the kinetic
 		diagram. Probabilities are either an array of numeric values
 		or the algebraic expressions. This attribute becomes available
-		after running the `build_state_probabilities` method.
+		after running the
+		:meth:`~kda.core.KineticModel.build_state_probabilities` method.
+
 	"""
 
 	def __init__(self, K=None, G=None):
 		"""
 		Parameters
 		==========
-	    K : ndarray (optional)
-	        'NxN' array where 'N' is the number of nodes in the diagram `G`.
-	        Adjacency matrix for `G` where each element kij is the edge weight
-	        (i.e. transition rate constant). For example, for a 2-state model
-	        with `k12=3` and `k21=4`, `K=[[0, 3], [4, 0]]`. Default is `None`.
-	    G : NetworkX MultiDiGraph (optional)
-	        Input diagram. Default is `None`.
+		K : ndarray (optional)
+			``NxN`` array where ``N`` is the number of nodes in the
+			diagram ``G``. Adjacency matrix for ``G`` where each element
+			``kij`` is the edge weight (i.e. transition rate constant).
+			For example, for a 2-state model with ``k12=3`` and ``k21=4``,
+			``K=[[0, 3], [4, 0]]``. Default is ``None``.
+		G : NetworkX MultiDiGraph (optional)
+			Input diagram. Default is ``None``.
 
 		Raises
-	    ======
-	    RuntimeError
-	    	If both `K` and `G` are `None`.
+		======
+		RuntimeError
+			If both ``K`` and ``G`` are ``None``.
 		"""
 		if G is None or K is None:
 			if K is not None:
@@ -87,31 +102,43 @@ class KineticModel(object):
 
 
 	def build_cycles(self):
-		"""Builds all cycles from the kinetic diagram."""
+		"""Builds all cycles from the kinetic diagram using
+		:meth:`~kda.graph_utils.find_all_unique_cycles()`.
+		"""
 		self.cycles = graph_utils.find_all_unique_cycles(self.G)
 
 
 	def build_partial_diagrams(self):
-		"""Builds the partial diagrams for the kinetic diagram."""
+		"""Builds the partial diagrams for the kinetic diagram using
+		:meth:`~kda.diagrams.generate_partial_diagrams()`.
+		"""
 		self.partial_diagrams = diagrams.generate_partial_diagrams(
 			self.G, return_edges=False)
 
 
 	def build_directional_diagrams(self):
-		"""Builds the directional diagrams for the kinetic diagram."""
+		"""Builds the directional diagrams for the kinetic diagram using
+		:meth:`~kda.diagrams.generate_directional_diagrams()`.
+		"""
 		self.directional_diagrams = diagrams.generate_directional_diagrams(
 			self.G, return_edges=False)
 
 
 	def build_flux_diagrams(self):
-		"""Builds the flux diagrams for the kinetic diagram."""
+		"""Builds the flux diagrams for the kinetic diagram using
+		:meth:`~kda.diagrams.generate_all_flux_diagrams()`.
+		"""
 		self.flux_diagrams = diagrams.generate_all_flux_diagrams(self.G)
 
 
 	def get_partial_diagram_count(self):
 		"""
-		Retrieves the number of partial diagrams that will
-		be created from the kinetic diagram.
+		Returns the number of partial diagrams that will
+		be created from the kinetic diagram. If partial diagrams
+		have already been generated with
+		:meth:`~kda.core.KineticModel.build_partial_diagrams()`
+		the count will simply be returned. Otherwise
+		:meth:`~kda.diagrams.enumerate_partial_diagrams()` is used.
 
 		Returns
 		=======
@@ -125,8 +152,14 @@ class KineticModel(object):
 
 	def get_directional_diagram_count(self):
 		"""
-		Retrieves the number of directional diagrams that will
-		be created from the kinetic diagram.
+		Returns the number of directional diagrams that will
+		be created from the kinetic diagram. If directional diagrams
+		have already been generated with
+		:meth:`~kda.core.KineticModel.build_directional_diagrams()`
+		the count will simply be returned. Otherwise
+		:meth:`~kda.core.KineticModel.get_partial_diagram_count()`
+		is used (there are ``N`` directional diagrams per partial
+		diagram for a kinetic diagram with ``N`` states).
 
 		Returns
 		=======
@@ -141,31 +174,36 @@ class KineticModel(object):
 
 	def get_flux_diagrams(self, cycle):
 		"""
-		Retrieves the flux diagrams for a specific cycle.
+		Retrieves the flux diagrams for a specific cycle using
+		:meth:`~kda.diagrams.generate_flux_diagrams()`.
 
 		Parameters
 		==========
-	    cycle : list of int
-	        List of node indices for cycle of interest, index zero.
-	        Order of node indices does not matter.
+		cycle : list of int
+			List of node indices for cycle of interest, index zero.
+			Order of node indices does not matter.
 
 		Returns
 		=======
 		The flux diagrams associated with the input cycle.
 		"""
+		# TODO: see if we can check if flux diagrams have been
+		# generated using `build_flux_diagrams`, then retrieve
+		# the correct diagrams based on `cycle`
 		return diagrams.generate_flux_diagrams(self.G, cycle)
 
 
 	def build_state_probabilities(self, symbolic=True):
 		"""
-		Builds the state probabilities for the kinetic diagram. Probabilities
+		Builds the state probabilities for the kinetic diagram using
+		:meth:`~kda.calculations.calc_state_probs()`. Probabilities
 		can be stored as raw values or symbolic algebraic expressions.
 
 		Parameters
 		==========
-	    symbolic : bool (optional)
-	        Used to determine whether raw values or symbolic
-	        expressions will be stored. Default is True.
+		symbolic : bool (optional)
+			Used to determine whether raw values or symbolic
+			expressions will be stored. Default is ``True``.
 		"""
 		# TODO: may be able to leverage `calc_state_probs_from_diags()`
 		# here, but it would require the user has already generated the
@@ -183,10 +221,9 @@ class KineticModel(object):
 
 
 	def get_transition_flux(self, state_i, state_j, net=True, symbolic=True):
-		"""
-		Creates the one-way or net transition fluxes between two states.
-		Net transition fluxes are calculated `J_ij = j_ij - j_ji`, where
-		`j_ij = k_ij * p_i` and `j_ji = k_ji * p_j`.
+		r"""
+		Generates the expressions for the one-way or net
+		transition fluxes between two states.
 
 		Parameters
 		==========
@@ -197,24 +234,41 @@ class KineticModel(object):
 		net : bool (optional)
 			Used to determine whether one-way transition fluxes
 			or net transition fluxes will be returned. Default
-			is True.
-	    symbolic : bool (optional)
-	        Used to determine whether raw values or symbolic
-	        expressions will be returned. Default is True.
+			is ``True``.
+		symbolic : bool (optional)
+			Used to determine whether raw values or symbolic
+			expressions will be returned. Default is ``True``.
 
 		Returns
 		=======
-		The transition flux (either one-way or net) from
-		state `i` to state `j`.
+		The transition flux (either one-way or net) from state ``i`` to
+		state ``j``.
 
-	    Raises
-	    ======
-	    ValueError
-	    	If the input states are the same (i.e. `i==j`).
-	    TypeError
-	    	If the stored state probability type (symbolic or numeric)
-	    	is a differnt type than the requested transition
-	    	flux type.
+		Raises
+		======
+		ValueError
+			If the input states are the same (i.e. ``i==j``).
+		TypeError
+			If the stored state probability type (symbolic or numeric)
+			is a differnt type than the requested transition
+			flux type.
+
+		Notes
+		-----
+		The expressions generated here quantify the one-way or
+		net probability flows between two states. The net transition flux
+		between two states is defined :footcite:`hill_free_1989`,
+
+		.. math::
+
+			J_{ij} = j_{ij} - j_{ji},
+
+		where :math:`j_{ij} = k_{ij} p_{i}` and :math:`j_{ji} = k_{ji} p_{j}`
+		are the one-way transition fluxes. For the one-way fluxes,
+		:math:`k_{ij}` is the kinetic rate from state :math:`i`
+		to state :math:`j` and :math:`p_{i}` is the state probability
+		for state :math:`i`.
+
 		"""
 		if state_i == state_j:
 			msg = "Input indices must be unique (i.e. i != j)."

--- a/kda/tests/test_kda.py
+++ b/kda/tests/test_kda.py
@@ -1362,7 +1362,7 @@ class TestTransitionFluxes:
         ],
     )
     def test_3_state_model_symbolic(self, i, j):
-        # verify the symbolic results of KineticModel.transition_flux
+        # verify the symbolic results of KineticModel.get_transition_flux
 
         # use rate matrix for a 3-state model
         K = np.array([
@@ -1372,10 +1372,14 @@ class TestTransitionFluxes:
         ])
         # create the transition flux using KDA
         model = kda.KineticModel(K=K, G=None)
-        j_ij_actual = model.transition_flux(i=i, j=j, net=False, symbolic=True)
-        j_ji_actual = model.transition_flux(i=j, j=i, net=False, symbolic=True)
-        J_ij_actual = model.transition_flux(i=i, j=j, net=True, symbolic=True)
-        J_ji_actual = model.transition_flux(i=j, j=i, net=True, symbolic=True)
+        j_ij_actual = model.get_transition_flux(
+            state_i=i, state_j=j, net=False, symbolic=True)
+        j_ji_actual = model.get_transition_flux(
+            state_i=j, state_j=i, net=False, symbolic=True)
+        J_ij_actual = model.get_transition_flux(
+            state_i=i, state_j=j, net=True, symbolic=True)
+        J_ji_actual = model.get_transition_flux(
+            state_i=j, state_j=i, net=True, symbolic=True)
 
         # create the transition flux using the known
         # solutions for the probability expressions
@@ -1402,7 +1406,7 @@ class TestTransitionFluxes:
         ],
     )
     def test_3_state_model_numeric(self, i, j, Model_3_State):
-        # verify the numeric results of KineticModel.transition_flux
+        # verify the numeric results of KineticModel.get_transition_flux
 
         # use rate matrix for a 3-state model
         K = np.array([
@@ -1412,10 +1416,14 @@ class TestTransitionFluxes:
         ])
         # calcuate the transition flux using KDA
         model = kda.KineticModel(K=K, G=None)
-        j_ij_actual = model.transition_flux(i=i, j=j, net=False, symbolic=False)
-        j_ji_actual = model.transition_flux(i=j, j=i, net=False, symbolic=False)
-        J_ij_actual = model.transition_flux(i=i, j=j, net=True, symbolic=False)
-        J_ji_actual = model.transition_flux(i=j, j=i, net=True, symbolic=False)
+        j_ij_actual = model.get_transition_flux(
+            state_i=i, state_j=j, net=False, symbolic=False)
+        j_ji_actual = model.get_transition_flux(
+            state_i=j, state_j=i, net=False, symbolic=False)
+        J_ij_actual = model.get_transition_flux(
+            state_i=i, state_j=j, net=True, symbolic=False)
+        J_ji_actual = model.get_transition_flux(
+            state_i=j, state_j=i, net=True, symbolic=False)
 
         # calculate the transition flux using the known
         # solutions for the probability expressions
@@ -1428,7 +1436,7 @@ class TestTransitionFluxes:
         j_ji_expected = K[j-1, i-1] * probs[j-1]
         # Net transition flux: J_ij = j_ij - j_ji
         J_ij_expected = j_ij_expected - j_ji_expected
-        J_ji_expected = -J_ij_expected
+        J_ji_expected = j_ji_expected - j_ij_expected
 
         # verify values are numerically indistinguishable
         assert_almost_equal(j_ij_actual, j_ij_expected, decimal=16)
@@ -1439,7 +1447,7 @@ class TestTransitionFluxes:
 
     def test_transition_flux_matching_indices(self):
         # verifies a ValueError is raised when matching
-        # indices are input to KineticModel.transition_flux
+        # indices are input to KineticModel.get_transition_flux
 
         # use rate matrix for the simple 3-state model
         K = np.array([
@@ -1453,7 +1461,7 @@ class TestTransitionFluxes:
         model = kda.KineticModel(K=None, G=G)
 
         with pytest.raises(ValueError):
-            model.transition_flux(i=1, j=1)
+            model.get_transition_flux(state_i=1, state_j=1)
 
 
     def test_transition_flux_mismatched_symbolic(self):
@@ -1475,4 +1483,4 @@ class TestTransitionFluxes:
         with pytest.raises(TypeError):
             # attempt to build the symbolic transition
             # flux expressions
-            model.transition_flux(i=1, j=2, symbolic=True)
+            model.get_transition_flux(state_i=1, state_j=2, symbolic=True)

--- a/kda/tests/test_kda.py
+++ b/kda/tests/test_kda.py
@@ -1133,11 +1133,6 @@ def test_ccw():
 
 class TestTransitionFluxes:
 
-    @pytest.fixture(scope="class")
-    def Model_3_State(k_vals):
-        return StateProbs3(k_vals)
-
-
     @pytest.mark.parametrize(
         "i, j",
         [
@@ -1268,3 +1263,10 @@ class TestTransitionFluxes:
             # attempt to build the symbolic transition
             # flux expressions
             model.get_transition_flux(state_i=1, state_j=2, symbolic=True)
+
+
+class TestKineticModel:
+
+    def test_invalid_inputs(self):
+        with pytest.raises(RuntimeError):
+            model = kda.KineticModel(K=None, G=None)

--- a/kda/tests/test_kda.py
+++ b/kda/tests/test_kda.py
@@ -28,221 +28,6 @@ from kda.exceptions import CycleError
     "state_probs_6_state",
     "symbolic_state_probs_6_state",
     )
-class StateProbs3:
-    def __init__(self, k_vals):
-        self.k_vals = k_vals
-
-    def return_probs(self, k12, k21, k23, k32, k13, k31):
-        P1 = k23 * k31 + k32 * k21 + k31 * k21
-        P2 = k13 * k32 + k32 * k12 + k31 * k12
-        P3 = k13 * k23 + k12 * k23 + k21 * k13
-        Sigma = P1 + P2 + P3  # Normalization factor
-        return np.array([P1, P2, P3]) / Sigma
-
-    def get_prob_expressions():
-        p_funcs = [
-            "k23 * k31 + k32 * k21 + k31 * k21",
-            "k13 * k32 + k32 * k12 + k31 * k12",
-            "k13 * k23 + k12 * k23 + k21 * k13",
-        ]
-        Sigma = "+".join(p_funcs)
-        exprs = expressions.construct_sympy_prob_funcs(p_funcs, Sigma)
-        return exprs
-
-
-class StateProbs4:
-    def __init__(self, k_vals):
-        self.k_vals = k_vals
-
-    def return_probs(self, k12, k21, k23, k32, k34, k43, k41, k14):
-        P1 = k43 * k32 * k21 + k23 * k34 * k41 + k21 * k34 * k41 + k41 * k32 * k21
-        P2 = k12 * k43 * k32 + k14 * k43 * k32 + k34 * k41 * k12 + k32 * k41 * k12
-        P3 = k43 * k12 * k23 + k23 * k14 * k43 + k21 * k14 * k43 + k41 * k12 * k23
-        P4 = k12 * k23 * k34 + k14 * k23 * k34 + k34 * k21 * k14 + k32 * k21 * k14
-        Sigma = P1 + P2 + P3 + P4  # Normalization factor
-        return np.array([P1, P2, P3, P4]) / Sigma
-
-
-class StateProbs4WL:
-    def __init__(self, k_vals):
-        self.k_vals = k_vals
-
-    def return_probs(self, k12, k21, k23, k32, k34, k43, k41, k14, k24, k42):
-        P1 = (
-            k43 * k32 * k21
-            + k23 * k34 * k41
-            + k21 * k34 * k41
-            + k41 * k32 * k21
-            + k32 * k42 * k21
-            + k24 * k34 * k41
-            + k34 * k42 * k21
-            + k32 * k24 * k41
-        )
-        P2 = (
-            k12 * k43 * k32
-            + k14 * k43 * k32
-            + k34 * k41 * k12
-            + k32 * k41 * k12
-            + k32 * k42 * k12
-            + k34 * k14 * k42
-            + k12 * k34 * k42
-            + k32 * k14 * k42
-        )
-        P3 = (
-            k43 * k12 * k23
-            + k23 * k14 * k43
-            + k21 * k14 * k43
-            + k41 * k12 * k23
-            + k12 * k42 * k23
-            + k14 * k24 * k43
-            + k12 * k24 * k43
-            + k14 * k42 * k23
-        )
-        P4 = (
-            k12 * k23 * k34
-            + k14 * k23 * k34
-            + k34 * k21 * k14
-            + k32 * k21 * k14
-            + k32 * k12 * k24
-            + k14 * k24 * k34
-            + k34 * k12 * k24
-            + k14 * k32 * k24
-        )
-        Sigma = P1 + P2 + P3 + P4  # Normalization factor
-        return np.array([P1, P2, P3, P4]) / Sigma
-
-
-class StateProbs5WL:
-    def __init__(self, k_vals):
-        self.k_vals = k_vals
-
-    def return_probs(self, k12, k21, k23, k32, k13, k31, k24, k42, k35, k53, k45, k54):
-        P1 = (
-            k35 * k54 * k42 * k21
-            + k24 * k45 * k53 * k31
-            + k21 * k45 * k53 * k31
-            + k42 * k21 * k53 * k31
-            + k54 * k42 * k21 * k31
-            + k54 * k42 * k32 * k21
-            + k45 * k53 * k23 * k31
-            + k53 * k32 * k42 * k21
-            + k42 * k23 * k53 * k31
-            + k54 * k42 * k23 * k31
-            + k45 * k53 * k32 * k21
-        )
-        P2 = (
-            k12 * k35 * k54 * k42
-            + k13 * k35 * k54 * k42
-            + k45 * k53 * k31 * k12
-            + k42 * k53 * k31 * k12
-            + k31 * k12 * k54 * k42
-            + k54 * k42 * k32 * k12
-            + k45 * k53 * k13 * k32
-            + k53 * k32 * k42 * k12
-            + k53 * k13 * k32 * k42
-            + k54 * k42 * k13 * k32
-            + k45 * k53 * k32 * k12
-        )
-        P3 = (
-            k12 * k24 * k45 * k53
-            + k13 * k24 * k45 * k53
-            + k21 * k13 * k45 * k53
-            + k42 * k21 * k13 * k53
-            + k54 * k42 * k21 * k13
-            + k54 * k42 * k12 * k23
-            + k45 * k53 * k23 * k13
-            + k42 * k12 * k23 * k53
-            + k42 * k23 * k13 * k53
-            + k54 * k42 * k23 * k13
-            + k45 * k53 * k12 * k23
-        )
-        P4 = (
-            k12 * k24 * k35 * k54
-            + k24 * k13 * k35 * k54
-            + k21 * k13 * k35 * k54
-            + k53 * k31 * k12 * k24
-            + k54 * k31 * k12 * k24
-            + k12 * k32 * k24 * k54
-            + k13 * k23 * k35 * k54
-            + k53 * k32 * k12 * k24
-            + k13 * k53 * k32 * k24
-            + k13 * k32 * k24 * k54
-            + k12 * k23 * k35 * k54
-        )
-        P5 = (
-            k35 * k12 * k24 * k45
-            + k13 * k35 * k24 * k45
-            + k45 * k21 * k13 * k35
-            + k42 * k21 * k13 * k35
-            + k31 * k12 * k24 * k45
-            + k12 * k32 * k24 * k45
-            + k13 * k23 * k35 * k45
-            + k12 * k42 * k23 * k35
-            + k42 * k23 * k13 * k35
-            + k13 * k32 * k24 * k45
-            + k12 * k23 * k35 * k45
-        )
-        Sigma = P1 + P2 + P3 + P4 + P5  # Normalization factor
-        return np.array([P1, P2, P3, P4, P5]) / Sigma
-
-
-class StateProbs6:
-    def __init__(self, k_vals):
-        self.k_vals = k_vals
-
-    def return_probs(self, k12, k21, k23, k32, k34, k43, k45, k54, k56, k65, k61, k16):
-        P1 = (
-            k65 * k54 * k43 * k32 * k21
-            + k61 * k54 * k43 * k32 * k21
-            + k56 * k61 * k43 * k32 * k21
-            + k45 * k56 * k61 * k32 * k21
-            + k34 * k45 * k56 * k61 * k21
-            + k23 * k34 * k45 * k56 * k61
-        )
-        P2 = (
-            k12 * k65 * k54 * k43 * k32
-            + k61 * k12 * k54 * k43 * k32
-            + k56 * k61 * k12 * k43 * k32
-            + k45 * k56 * k61 * k32 * k12
-            + k34 * k45 * k56 * k61 * k12
-            + k16 * k65 * k54 * k43 * k32
-        )
-        P3 = (
-            k12 * k23 * k65 * k54 * k43
-            + k61 * k12 * k23 * k54 * k43
-            + k56 * k61 * k12 * k23 * k43
-            + k45 * k56 * k61 * k12 * k23
-            + k21 * k16 * k65 * k54 * k43
-            + k23 * k16 * k65 * k54 * k43
-        )
-        P4 = (
-            k65 * k54 * k12 * k23 * k34
-            + k54 * k61 * k12 * k23 * k34
-            + k56 * k61 * k12 * k23 * k34
-            + k32 * k21 * k16 * k65 * k54
-            + k21 * k16 * k65 * k54 * k34
-            + k16 * k65 * k54 * k23 * k34
-        )
-        P5 = (
-            k65 * k12 * k23 * k34 * k45
-            + k61 * k12 * k23 * k34 * k45
-            + k43 * k32 * k21 * k16 * k65
-            + k45 * k32 * k21 * k16 * k65
-            + k34 * k45 * k21 * k16 * k65
-            + k23 * k34 * k45 * k16 * k65
-        )
-        P6 = (
-            k12 * k23 * k34 * k45 * k56
-            + k54 * k43 * k32 * k21 * k16
-            + k56 * k43 * k32 * k21 * k16
-            + k45 * k56 * k32 * k21 * k16
-            + k34 * k45 * k56 * k21 * k16
-            + k16 * k23 * k34 * k45 * k56
-        )
-        Sigma = P1 + P2 + P3 + P4 + P5 + P6  # Normalization factor
-        return np.array([P1, P2, P3, P4, P5, P6]) / Sigma
-
-
 class Test_Probability_Calcs:
 
     @settings(deadline=None)
@@ -1361,7 +1146,7 @@ class TestTransitionFluxes:
             (1, 3),
         ],
     )
-    def test_3_state_model_symbolic(self, i, j):
+    def test_3_state_model_symbolic(self, i, j, symbolic_state_probs_3_state):
         # verify the symbolic results of KineticModel.get_transition_flux
 
         # use rate matrix for a 3-state model
@@ -1383,10 +1168,9 @@ class TestTransitionFluxes:
 
         # create the transition flux using the known
         # solutions for the probability expressions
-        prob_exprs = StateProbs3.get_prob_expressions()
         # One-way transition flux: j_ij = k_ij * p_i
-        j_ij_expected = symbols(f"k{i}{j}") * prob_exprs[i-1]
-        j_ji_expected = symbols(f"k{j}{i}") * prob_exprs[j-1]
+        j_ij_expected = symbols(f"k{i}{j}") * symbolic_state_probs_3_state[i-1]
+        j_ji_expected = symbols(f"k{j}{i}") * symbolic_state_probs_3_state[j-1]
         J_ij_expected = j_ij_expected - j_ji_expected
         J_ji_expected = j_ji_expected - j_ij_expected
 
@@ -1405,7 +1189,7 @@ class TestTransitionFluxes:
             (1, 3),
         ],
     )
-    def test_3_state_model_numeric(self, i, j, Model_3_State):
+    def test_3_state_model_numeric(self, i, j, state_probs_3_state):
         # verify the numeric results of KineticModel.get_transition_flux
 
         # use rate matrix for a 3-state model
@@ -1427,7 +1211,7 @@ class TestTransitionFluxes:
 
         # calculate the transition flux using the known
         # solutions for the probability expressions
-        probs = Model_3_State.return_probs(
+        probs = state_probs_3_state(
             k12=K[0, 1], k21=K[1, 0], k23=K[1, 2],
             k32=K[2, 1], k13=K[0, 2], k31=K[2, 0],
         )


### PR DESCRIPTION
## Description
* Add `core.py` with new class object `KineticModel` used to create and store
model information for kinetic diagrams

* Add `KineticModel` import to `__init__.py` so new API is accessible by importing `kda`

* Fixes issue #68

## Todos
  - [x] Add documentation for `KineticModel`
  - [x] Add documentation for `KineticModel` methods
  - [x] Update main `README` to reflect API changes
  - [x] Add, modify, etc. tests such that `core.py` code is covered
  - [x] Update docs (i.e. `` instead of `) 
  - [x] Add `core.py` to docs (i.e. `api.rst`)
  - [x] Update `usage.rst` to match `README`
  - [x] Test KDA paper code to ensure there are no backwards incompatible changes

## Upstream Todos (handle separately)

~Fix [issue #56](https://github.com/Becksteinlab/kda/issues/56) -- remove the usage of `"name"`/`"val"` `dict` keys for all `kda` functions. I don't think this is a particularly useful feature and it will likely require a lot of code to keep it working. _Instead_ we should simply store the edge _value_ under the `NetworkX` default `"weight"` key. There is no reason to store "k12" as an edge weight under `"name"` for edge `(0, 1)` when the information is already available in the edge tuple. Also, if we do this we can likely remove both `graph_utils.generate_edges(G)` and `graph_utils.retrieve_rate_matrix(K)` and simply use the `NetworkX` built-in functions (e.g. `nx.from_numpy_array(K, create_using=nx.MultiDiGraph)`).~

## Comments

I'm still working out how to handle some of the cycle-based tasks. I need to figure out a good solution for cycles that allows the user to either input the cycle info (i.e. direction, substrate transport per cycle, etc.) or input general state info and automatically determine the cycle info. I haven't come up with anything novel so I'll likely leave that for later. 

As it stands the API is already _much easier_ to use than before, especially for transition fluxes (see script below).

## Testing/Example Script

<details>
<summary> Testing Script </summary>

```python
import numpy as np

import kda

if __name__ == "__main__":

	K = np.array(
	    [
	        [0, 1, 0, 1],
	        [1, 0, 1, 1],
	        [0, 1, 0, 1],
	        [1, 1, 1, 0],
	    ]
	)

	model = kda.KineticModel(K=K, G=None)
	model.build_cycles()
	model.build_partial_diagrams()
	model.build_directional_diagrams()
	model.build_state_probabilities(symbolic=True)

	print(model.K)
	print(model.G)
	print(model.cycles)
	print(len(model.partial_diagrams))
	print(model.get_partial_diagram_count())
	print(len(model.directional_diagrams))
	print(model.get_directional_diagram_count())

	for (i, j) in model.G.edges():
		flux = model.transition_flux(i=i, j=j, net=False, symbolic=True)
		print(f">>> j_{i}{j} = {flux}")
```

</details>

## Status
- [ ] Ready to go