### PR TITLE
ENH, API: Remove "key" and "name" parameters

### DIFF
--- a/kda/calculations.py
+++ b/kda/calculations.py
@@ -96,7 +96,7 @@ def _get_ordered_cycle(G, input_cycle):
             )
 
 
-def calc_sigma(G, dirpar_edges, key, output_strings=False):
+def calc_sigma(G, dirpar_edges, output_strings=False):
     """
     Calculates sigma, the normalization factor for calculating state
     probabilities and cycle fluxes for a given diagram G.
@@ -107,16 +107,9 @@ def calc_sigma(G, dirpar_edges, key, output_strings=False):
         Input diagram
     dirpar_edges : list
         List of all directional partial diagrams for the input diagram G.
-    key : str
-        Definition of key in NetworkX diagram edges, used to call edge rate
-        values or names. This needs to match the key used for the rate
-        constants names or values in the input diagram G.
     output_strings : bool (optional)
-        Used to denote whether values or strings will be combined. Default
-        is False, which tells the function to calculate the normalization factor
-        using numbers. If True, this will assume the input
-        'key' will return strings of variable names to join into the
-        analytic cycle flux function.
+        Used to determine whether raw values or strings of variables
+        will be returned. Default is False.
     Returns
     -------
     sigma : float
@@ -128,41 +121,32 @@ def calc_sigma(G, dirpar_edges, key, output_strings=False):
     # Number of nodes/states
     n_states = G.number_of_nodes()
     n_dirpars = dirpar_edges.shape[0]
-    edge_value = G.edges[list(G.edges)[0]][key]
 
     if not output_strings:
-        if isinstance(edge_value, str):
-            raise TypeError(
-                "To enter variable strings set parameter output_strings=True."
-            )
         dirpar_rate_products = np.ones(n_dirpars, dtype=float)
         # iterate over the directional partial diagrams
         for i, edge_list in enumerate(dirpar_edges):
             # iterate over the edges in the given directional partial diagram i
             for edge in edge_list:
                 # multiply the rate of each edge in edge_list
-                dirpar_rate_products[i] *= G.edges[edge][key]
+                dirpar_rate_products[i] *= G.edges[edge]["weight"]
         sigma = math.fsum(dirpar_rate_products)
         return sigma
     elif output_strings:
-        if not isinstance(edge_value, str):
-            raise TypeError(
-                "To enter variable values set parameter output_strings=False."
-            )
         dirpar_rate_products = np.empty(shape=(n_dirpars,), dtype=object)
         # iterate over the directional partial diagrams
         for i, edge_list in enumerate(dirpar_edges):
             rate_product_vals = []
             for edge in edge_list:
-                # append rate constant names from dir_par to list
-                rate_product_vals.append(G.edges[edge][key])
+                # append index-1 rate constant name from dir_par to list
+                rate_product_vals.append(f"k{edge[0]+1}{edge[1]+1}")
             dirpar_rate_products[i] = "*".join(rate_product_vals)
         # sum all terms to get normalization factor
         sigma_str = "+".join(dirpar_rate_products)
         return sigma_str
 
 
-def calc_sigma_K(G, cycle, flux_diags, key, output_strings=False):
+def calc_sigma_K(G, cycle, flux_diags, output_strings=False):
     """
     Calculates sigma_K, the sum of all directional flux diagrams.
 
@@ -175,16 +159,9 @@ def calc_sigma_K(G, cycle, flux_diags, key, output_strings=False):
         indices does not matter but should not contain all nodes.
     flux_diags : list
         List of relevant directional flux diagrams for input cycle.
-    key : str
-        Definition of key in NetworkX diagram edges, used to call edge rate
-        values or names. This needs to match the key used for the rate
-        constants names or values in the input diagram G.
     output_strings : bool (optional)
-        Used to denote whether values or strings will be combined. Default
-        is False, which tells the function to calculate the sum of all
-        directional flux diagrams using numbers. If True, this will assume the
-        input 'key' will return strings of variable names to join into the
-        analytic function.
+        Used to determine whether raw values or strings of variables
+        will be returned. Default is False.
 
     Returns
     -------
@@ -205,13 +182,6 @@ def calc_sigma_K(G, cycle, flux_diags, key, output_strings=False):
         ordered_cycle = _get_ordered_cycle(G, cycle)
         cycle_edges = diagrams._construct_cycle_edges(ordered_cycle)
         if output_strings == False:
-            if isinstance(
-                G.edges[cycle_edges[0][0], cycle_edges[0][1], cycle_edges[0][2]][key],
-                str,
-            ):
-                raise TypeError(
-                    "To enter variable strings set parameter output_strings=True."
-                )
             rate_products = []
             for diagram in flux_diags:
                 diag = diagram.copy()
@@ -220,18 +190,11 @@ def calc_sigma_K(G, cycle, flux_diags, key, output_strings=False):
                     diag.remove_edge(edge[1], edge[0], edge[2])
                 vals = 1
                 for edge in diag.edges:
-                    vals *= G.edges[edge[0], edge[1], edge[2]][key]
+                    vals *= G.edges[edge[0], edge[1], edge[2]]["weight"]
                 rate_products.append(vals)
             sigma_K = math.fsum(rate_products)
             return sigma_K
         elif output_strings == True:
-            if not isinstance(
-                G.edges[cycle_edges[0][0], cycle_edges[0][1], cycle_edges[0][2]][key],
-                str,
-            ):
-                raise TypeError(
-                    "To enter variable values set parameter output_strings=False."
-                )
             rate_products = []
             for diagram in flux_diags:
                 diag = diagram.copy()
@@ -240,13 +203,13 @@ def calc_sigma_K(G, cycle, flux_diags, key, output_strings=False):
                     diag.remove_edge(edge[1], edge[0], edge[2])
                 rates = []
                 for edge in diag.edges:
-                    rates.append(G.edges[edge[0], edge[1], edge[2]][key])
+                    rates.append(f"k{edge[0]+1}{edge[1]+1}")
                 rate_products.append("*".join(rates))
             sigma_K_str = "+".join(rate_products)
             return sigma_K_str
 
 
-def calc_pi_difference(G, cycle, order, key, output_strings=False):
+def calc_pi_difference(G, cycle, order, output_strings=False):
     """
     Calculates the difference of the forward and reverse rate products for a
     given cycle, where forward rates are defined as counter clockwise.
@@ -262,15 +225,9 @@ def calc_pi_difference(G, cycle, order, key, output_strings=False):
         List of integers of length 2, where the integers must be nodes in the
         input cycle. This pair of nodes is used to determine which direction is
         CCW.
-    key : str
-        Definition of key in NetworkX diagram edges, used to call edge rate
-        values or names. This needs to match the key used for the rate
-        constants names or values in the input diagram G.
     output_strings : bool (optional)
-        Used to denote whether values or strings will be combined. Default
-        is False, which tells the function to calculate the difference using
-        numbers. If True, this will assume the input 'key' will return strings
-        of variable names to join into the analytic function.
+        Used to determine whether raw values or strings of variables
+        will be returned. Default is False.
 
     Returns
     -------
@@ -286,36 +243,24 @@ def calc_pi_difference(G, cycle, order, key, output_strings=False):
     CCW_cycle = graph_utils.get_ccw_cycle(ordered_cycle, order)
     cycle_edges = diagrams._construct_cycle_edges(CCW_cycle)
     if output_strings == False:
-        if isinstance(
-            G.edges[cycle_edges[0][0], cycle_edges[0][1], cycle_edges[0][2]][key], str
-        ):
-            raise TypeError(
-                "To enter variable strings set parameter output_strings=True."
-            )
         ccw_rates = 1
         cw_rates = 1
         for edge in cycle_edges:
-            ccw_rates *= G.edges[edge[0], edge[1], edge[2]][key]
-            cw_rates *= G.edges[edge[1], edge[0], edge[2]][key]
+            ccw_rates *= G.edges[edge[0], edge[1], edge[2]]["weight"]
+            cw_rates *= G.edges[edge[1], edge[0], edge[2]]["weight"]
         pi_difference = ccw_rates - cw_rates
         return pi_difference
     elif output_strings == True:
-        if not isinstance(
-            G.edges[cycle_edges[0][0], cycle_edges[0][1], cycle_edges[0][2]][key], str
-        ):
-            raise TypeError(
-                "To enter variable values set parameter output_strings=False."
-            )
         ccw_rates = []
         cw_rates = []
         for edge in cycle_edges:
-            ccw_rates.append(G.edges[edge[0], edge[1], edge[2]][key])
-            cw_rates.append(G.edges[edge[1], edge[0], edge[2]][key])
+            ccw_rates.append(f"k{edge[0]+1}{edge[1]+1}")
+            cw_rates.append(f"k{edge[1]+1}{edge[0]+1}")
         pi_difference = "-".join(["*".join(ccw_rates), "*".join(cw_rates)])
         return pi_difference
 
 
-def calc_thermo_force(G, cycle, order, key, output_strings=False):
+def calc_thermo_force(G, cycle, order, output_strings=False):
     """
     Calculates the thermodynamic driving force for a given cycle in diagram G.
     The driving force is calculated as the natural log of the ratio of the
@@ -335,16 +280,9 @@ def calc_thermo_force(G, cycle, order, key, output_strings=False):
         List of integers of length 2, where the integers must be nodes in the
         input cycle. This pair of nodes is used to determine which direction is
         CCW.
-    key : str
-        Definition of key in NetworkX diagram edges, used to call edge rate
-        values or names. This needs to match the key used for the rate
-        constants names or values in the input diagram G.
     output_strings : bool (optional)
-        Used to denote whether values or strings will be combined. Default
-        is False, which tells the function to calculate the thermodynamic force
-        using numbers. If True, this will assume the input
-        'key' will return strings of variable names to join into the
-        analytic function.
+        Used to determine whether raw values or strings of variables
+        will be returned. Default is False.
 
     Returns
     -------
@@ -360,31 +298,19 @@ def calc_thermo_force(G, cycle, order, key, output_strings=False):
     CCW_cycle = graph_utils.get_ccw_cycle(ordered_cycle, order)
     cycle_edges = diagrams._construct_cycle_edges(CCW_cycle)
     if output_strings == False:
-        if isinstance(
-            G.edges[cycle_edges[0][0], cycle_edges[0][1], cycle_edges[0][2]][key], str
-        ):
-            raise TypeError(
-                "To enter variable strings set parameter output_strings=True."
-            )
         ccw_rates = 1
         cw_rates = 1
         for edge in cycle_edges:
-            ccw_rates *= G.edges[edge[0], edge[1], edge[2]][key]
-            cw_rates *= G.edges[edge[1], edge[0], edge[2]][key]
+            ccw_rates *= G.edges[edge[0], edge[1], edge[2]]["weight"]
+            cw_rates *= G.edges[edge[1], edge[0], edge[2]]["weight"]
         thermo_force = np.log(ccw_rates / cw_rates)
         return thermo_force
     elif output_strings == True:
-        if not isinstance(
-            G.edges[cycle_edges[0][0], cycle_edges[0][1], cycle_edges[0][2]][key], str
-        ):
-            raise TypeError(
-                "To enter variable values set parameter output_strings=False."
-            )
         ccw_rates = []
         cw_rates = []
         for edge in cycle_edges:
-            ccw_rates.append(G.edges[edge[0], edge[1], edge[2]][key])
-            cw_rates.append(G.edges[edge[1], edge[0], edge[2]][key])
+            ccw_rates.append(f"k{edge[0]+1}{edge[1]+1}")
+            cw_rates.append(f"k{edge[1]+1}{edge[0]+1}")
         thermo_force_str = (
             "ln(" + "*".join(ccw_rates) + ") - ln(" + "*".join(cw_rates) + ")"
         )
@@ -392,7 +318,7 @@ def calc_thermo_force(G, cycle, order, key, output_strings=False):
         return parsed_thermo_force_str
 
 
-def calc_state_probs(G, key, output_strings=False):
+def calc_state_probs(G, output_strings=False):
     """
     Calculates state probabilities directly.
 
@@ -400,16 +326,9 @@ def calc_state_probs(G, key, output_strings=False):
     ----------
     G : NetworkX MultiDiGraph Object
         Input diagram
-    key : str
-        Definition of key in NetworkX diagram edges, used to call edge rate
-        values or names. This needs to match the key used for the rate
-        constants names or values in the input diagram G.
     output_strings : bool (optional)
-        Used to denote whether values or strings will be combined. Default
-        is False, which tells the function to calculate the state
-        probabilities using numbers. If True, this will assume the input
-        'key' will return strings of variable names to join into the
-        analytic state multplicity and normalization function.
+        Used to determine whether raw values or strings of variables
+        will be returned. Default is False.
 
     Returns
     -------
@@ -421,18 +340,18 @@ def calc_state_probs(G, key, output_strings=False):
     dirpar_edges = diagrams.generate_directional_diagrams(G, return_edges=True)
     if output_strings == False:
         state_probs = calc_state_probs_from_diags(
-            G, dirpar_edges, key, output_strings=output_strings
+            G, dirpar_edges, output_strings=output_strings
         )
         return state_probs
     if output_strings == True:
         state_mults, norm = calc_state_probs_from_diags(
-            G, dirpar_edges, key, output_strings=output_strings
+            G, dirpar_edges, output_strings=output_strings
         )
         state_probs_sympy = expressions.construct_sympy_prob_funcs(state_mults, norm)
         return state_probs_sympy
 
 
-def calc_net_cycle_flux(G, cycle, order, key, output_strings=False):
+def calc_net_cycle_flux(G, cycle, order, output_strings=False):
     """
     Calculates net cycle flux for a given cycle in diagram G.
 
@@ -443,15 +362,9 @@ def calc_net_cycle_flux(G, cycle, order, key, output_strings=False):
     cycle : list of int
         List of node indices for cycle of interest, index zero. Order of node
         indices does not matter.
-    key : str
-        Definition of key in NetworkX diagram edges, used to call edge rate
-        values or names. This needs to match the key used for the rate
-        constants names or values in the input diagram G.
     output_strings : bool (optional)
-        Used to denote whether values or strings will be combined. Default
-        is False, which tells the function to calculate the cycle flux using
-        numbers. If True, this will assume the input 'key' will return strings
-        of variable names to join into the analytic cycle flux function.
+        Used to determine whether raw values or strings of variables
+        will be returned. Default is False.
 
     Returns
     -------
@@ -464,27 +377,27 @@ def calc_net_cycle_flux(G, cycle, order, key, output_strings=False):
     flux_diags = diagrams.generate_flux_diagrams(G, cycle)
     if output_strings == False:
         pi_diff = calc_pi_difference(
-            G, cycle, order, key, output_strings=output_strings
+            G, cycle, order, output_strings=output_strings
         )
-        sigma_K = calc_sigma_K(G, cycle, flux_diags, key, output_strings=output_strings)
-        sigma = calc_sigma(G, dirpar_edges, key, output_strings=output_strings)
+        sigma_K = calc_sigma_K(G, cycle, flux_diags, output_strings=output_strings)
+        sigma = calc_sigma(G, dirpar_edges, output_strings=output_strings)
         net_cycle_flux = pi_diff * sigma_K / sigma
         return net_cycle_flux
     if output_strings == True:
         pi_diff_str = calc_pi_difference(
-            G, cycle, order, key, output_strings=output_strings
+            G, cycle, order, output_strings=output_strings
         )
         sigma_K_str = calc_sigma_K(
-            G, cycle, flux_diags, key, output_strings=output_strings
+            G, cycle, flux_diags, output_strings=output_strings
         )
-        sigma_str = calc_sigma(G, dirpar_edges, key, output_strings=output_strings)
+        sigma_str = calc_sigma(G, dirpar_edges, output_strings=output_strings)
         sympy_net_cycle_flux_func = expressions.construct_sympy_net_cycle_flux_func(
             pi_diff_str, sigma_K_str, sigma_str
         )
         return sympy_net_cycle_flux_func
 
 
-def calc_state_probs_from_diags(G, dirpar_edges, key, output_strings=False):
+def calc_state_probs_from_diags(G, dirpar_edges, output_strings=False):
     """
     Calculates state probabilities and generates analytic function strings from
     input diagram and directional partial diagrams. If directional partial
@@ -497,16 +410,9 @@ def calc_state_probs_from_diags(G, dirpar_edges, key, output_strings=False):
         Input diagram
     dirpar_edges : array
         Array of all directional partial diagram edges (made from 2-tuples).
-    key : str
-        Definition of key in NetworkX diagram edges, used to call edge rate
-        values or names. This needs to match the key used for the rate
-        constants names or values in the input diagram G.
     output_strings : bool (optional)
-        Used to denote whether values or strings will be combined. Default
-        is False, which tells the function to calculate the state
-        probabilities using numbers. If True, this will assume the input
-        'key' will return strings of variable names to join into the
-        analytic state multplicity and normalization functions.
+        Used to determine whether raw values or strings of variables
+        will be returned. Default is False.
 
     Returns
     -------
@@ -527,12 +433,7 @@ def calc_state_probs_from_diags(G, dirpar_edges, key, output_strings=False):
     # retrieve the rate matrix from G
     Kij = graph_utils.retrieve_rate_matrix(G)
 
-    edge_value = G.edges[list(G.edges)[0]][key]
     if not output_strings:
-        if isinstance(edge_value, str):
-            raise TypeError(
-                "To enter variable strings set parameter output_strings=True."
-            )
         # create array of ones for storing rate products
         dirpar_rate_products = np.ones(n_dirpars, dtype=float)
         # iterate over the directional partial diagrams
@@ -552,15 +453,11 @@ def calc_state_probs_from_diags(G, dirpar_edges, key, output_strings=False):
             )
         return state_probs
     elif output_strings:
-        if not isinstance(edge_value, str):
-            raise TypeError(
-                "To enter variable values set parameter output_strings=False."
-            )
         dirpar_rate_products = np.empty(shape=(n_dirpars,), dtype=object)
         for i, edge_list in enumerate(dirpar_edges):
             rate_product_vals = []
             for edge in edge_list:
-                rate_product_vals.append(G.edges[edge][key])
+                rate_product_vals.append(f"k{edge[0]+1}{edge[1]+1}")
             dirpar_rate_products[i] = "*".join(rate_product_vals)
 
         state_mults = np.empty(shape=(n_states,), dtype=object)
@@ -573,7 +470,7 @@ def calc_state_probs_from_diags(G, dirpar_edges, key, output_strings=False):
 
 
 def calc_net_cycle_flux_from_diags(
-    G, dirpar_edges, cycle, order, key, output_strings=False
+    G, dirpar_edges, cycle, order, output_strings=False
 ):
     """
     Calculates net cycle flux and generates analytic function strings from
@@ -590,15 +487,9 @@ def calc_net_cycle_flux_from_diags(
     cycle : list of int
         List of node indices for cycle of interest, index zero. Order of node
         indices does not matter.
-    key : str
-        Definition of key in NetworkX diagram edges, used to call edge rate
-        values or names. This needs to match the key used for the rate
-        constants names or values in the input diagram G.
     output_strings : bool (optional)
-        Used to denote whether values or strings will be combined. Default
-        is False, which tells the function to calculate the cycle flux using
-        numbers. If True, this will assume the input 'key' will return strings
-        of variable names to join into the analytic cycle flux function.
+        Used to determine whether raw values or strings of variables
+        will be returned. Default is False.
 
     Returns
     -------
@@ -610,20 +501,20 @@ def calc_net_cycle_flux_from_diags(
     flux_diags = diagrams.generate_flux_diagrams(G, cycle)
     if output_strings == False:
         pi_diff = calc_pi_difference(
-            G, cycle, order, key, output_strings=output_strings
+            G, cycle, order, output_strings=output_strings
         )
-        sigma_K = calc_sigma_K(G, cycle, flux_diags, key, output_strings=output_strings)
-        sigma = calc_sigma(G, dirpar_edges, key, output_strings=output_strings)
+        sigma_K = calc_sigma_K(G, cycle, flux_diags, output_strings=output_strings)
+        sigma = calc_sigma(G, dirpar_edges, output_strings=output_strings)
         net_cycle_flux = pi_diff * sigma_K / sigma
         return net_cycle_flux
     if output_strings == True:
         pi_diff_str = calc_pi_difference(
-            G, cycle, order, key, output_strings=output_strings
+            G, cycle, order, output_strings=output_strings
         )
         sigma_K_str = calc_sigma_K(
-            G, cycle, flux_diags, key, output_strings=output_strings
+            G, cycle, flux_diags, output_strings=output_strings
         )
-        sigma_str = calc_sigma(G, dirpar_edges, key, output_strings=output_strings)
+        sigma_str = calc_sigma(G, dirpar_edges, output_strings=output_strings)
         sympy_net_cycle_flux_func = expressions.construct_sympy_net_cycle_flux_func(
             pi_diff_str, sigma_K_str, sigma_str
         )

--- a/kda/diagrams.py
+++ b/kda/diagrams.py
@@ -329,7 +329,7 @@ def enumerate_partial_diagrams(G):
         generated from a graph represented by the input rate matrix.
     """
     # get the adjacency matrix for K
-    K_adj = nx.to_numpy_array(G)
+    K_adj = nx.to_numpy_array(G, weight=None)
     # use the adjacency matrix to generate the Laplacian matrix
     # multiply through by -1
     K_laplace = -1 * K_adj

--- a/kda/graph_utils.py
+++ b/kda/graph_utils.py
@@ -50,46 +50,31 @@ def generate_K_string_matrix(N_states):
     return K_string
 
 
-def generate_edges(G, vals, names=None, val_key="val", name_key="name"):
+def generate_edges(G, K):
     """
-    Generate edges with attributes 'val' and 'name'.
+    Generates weighted edges for an input MultiDiGraph where the edge
+    weights are stored under the edge attribute 'weight'.
 
     Parameters
     ----------
     G : NetworkX MultiDiGraph
         Input diagram
-    vals : array
-        'NxN' array where 'N' is the number of nodes in the diagram G. Contains
-        the values associated with the attribute names in 'names'. For example,
-        assuming k12 and k21 had already been assigned values, for a 2 state
-        diagram 'vals' = [[0, k12], [k21, 0]].
-    names : array (optional)
-        'NxN' array where 'N' is the number of nodes in the diagram G. Contains
-        the names of all of the attributes corresponding to the values in
-        'vals' as strings, i.e. [[0, "k12"], ["k21", 0]].
-    val_key : str (optional)
-        Key used to retrieve variable values in 'vals'. Default is 'val'.
-    name_key : str (optional)
-        Key used to retrieve variable names in 'names'. Default is 'name'.
+    K : array
+        'NxN' array where 'N' is the number of nodes in the diagram G.
+        Adjacency matrix for G where each element kij is the edge weight
+        (i.e. transition rate constant). For example, for a 2-state model
+        with `k12=3` and `k21=4`, `K=[[0, 3], [4, 0]]`.
+
     """
-    if names is None:
-        names = generate_K_string_matrix(vals.shape[0])
-    if isinstance(vals[0, 0], str):
-        raise TypeError(
-            "Values entered for 'vals' must be integers or floats, not strings."
-        )
-    if not isinstance(names[0, 0], str):
-        raise TypeError("Labels entered for 'names' must be strings.")
-    np.fill_diagonal(vals, 0)  # Make sure diagonal elements are set to zero
+    np.fill_diagonal(K, 0)  # Make sure diagonal elements are set to zero
 
-    for i, row in enumerate(vals):
+    for i, row in enumerate(K):
         for j, elem in enumerate(row):
-            if not elem == 0:
-                attrs = {name_key: names[i, j], val_key: elem}
-                G.add_edge(i, j, **attrs)
+            if elem != 0:
+                G.add_edge(i, j, weight=elem)
 
 
-def retrieve_rate_matrix(G, key="val"):
+def retrieve_rate_matrix(G):
     """
     Retrieves rate matrix from edge data stored in input diagram G.
 
@@ -97,24 +82,18 @@ def retrieve_rate_matrix(G, key="val"):
     ----------
     G : NetworkX MultiDiGraph
         Input diagram
-    val : str (optional)
-        Key used to retrieve values from edges. Default is 'val'.
 
     Returns
     -------
     rate_matrix : array
-        'NxN' array where 'N' is the number of nodes/states in the diagram G.
-        Contains the values/rates for each edge.
+        'NxN' array where 'N' is the number of nodes in the diagram G.
+        Adjacency matrix for G where each element kij is the edge weight
+        (i.e. transition rate constant). For example, for a 2-state model
+        with `k12=3` and `k21=4`, `K=[[0, 3], [4, 0]]`.
     """
-    # get the number of states
-    n_states = G.number_of_nodes()
-    # create `n_states x n_states` zero-array
-    rate_matrix = np.zeros(shape=(n_states, n_states), dtype=float)
-    # iterate over edges
-    for edge in G.edges(data=True):
-        i, j, data = edge
-        # use edge indices and edge values to construct rate matrix
-        rate_matrix[i, j] = data[key]
+    # sort the nodes in increasing order
+    nodelist = sorted(G.nodes())
+    rate_matrix = nx.to_numpy_array(G, nodelist=nodelist)
     return rate_matrix
 
 

--- a/kda/graph_utils.py
+++ b/kda/graph_utils.py
@@ -24,32 +24,6 @@ import networkx as nx
 from kda.exceptions import CycleError
 
 
-def generate_K_string_matrix(N_states):
-    """
-    Creates the string variant of the K-matrix based on the number of states
-    in a diagram.
-
-    Parameters
-    ==========
-    N_states : int
-        The number of states in a diagram used to create a `NxN` matrix of
-        strings.
-
-    Returns
-    =======
-    K_string : NumPy array
-        An `NxN` array of strings where `N` is the number of states in a
-        diagram and the diaganol values of the array are zeros.
-    """
-    K_string = []
-    for i in range(N_states):
-        for j in range(N_states):
-            K_string.append(f"k{i+1}{j+1}")
-    K_string = np.array(K_string).reshape((N_states, N_states))
-    np.fill_diagonal(K_string, val=0)
-    return K_string
-
-
 def generate_edges(G, K):
     """
     Generates weighted edges for an input MultiDiGraph where the edge

--- a/kda/tests/test_kda.py
+++ b/kda/tests/test_kda.py
@@ -255,10 +255,10 @@ class Test_Probability_Calcs:
         graph_utils.generate_edges(G, K)
 
         # calculate the state probabilities using KDA
-        kda_probs = calculations.calc_state_probs(G, key="val")
+        kda_probs = calculations.calc_state_probs(G)
 
         # generate the sympy functions for the state probabilities
-        sympy_funcs = calculations.calc_state_probs(G, key="name", output_strings=True)
+        sympy_funcs = calculations.calc_state_probs(G, output_strings=True)
         rate_names = ["k12", "k21", "k23", "k32", "k13", "k31"]
         sympy_prob_funcs = expressions.construct_lambda_funcs(
             sympy_funcs=sympy_funcs, rate_names=rate_names
@@ -313,10 +313,10 @@ class Test_Probability_Calcs:
         graph_utils.generate_edges(G, K)
 
         # calculate the state probabilities using KDA
-        kda_probs = calculations.calc_state_probs(G, key="val")
+        kda_probs = calculations.calc_state_probs(G)
 
         # generate the sympy functions for the state probabilities
-        sympy_funcs = calculations.calc_state_probs(G, key="name", output_strings=True)
+        sympy_funcs = calculations.calc_state_probs(G, output_strings=True)
         rate_names = ["k12", "k21", "k23", "k32", "k34", "k43", "k41", "k14"]
         sympy_prob_funcs = expressions.construct_lambda_funcs(
             sympy_funcs=sympy_funcs, rate_names=rate_names
@@ -373,10 +373,10 @@ class Test_Probability_Calcs:
         graph_utils.generate_edges(G, K)
 
         # calculate the state probabilities using KDA
-        kda_probs = calculations.calc_state_probs(G, key="val")
+        kda_probs = calculations.calc_state_probs(G)
 
         # generate the sympy functions for the state probabilities
-        sympy_funcs = calculations.calc_state_probs(G, key="name", output_strings=True)
+        sympy_funcs = calculations.calc_state_probs(G, output_strings=True)
         rate_names = [
             "k12",
             "k21",
@@ -452,10 +452,10 @@ class Test_Probability_Calcs:
         graph_utils.generate_edges(G, K)
 
         # calculate the state probabilities using KDA
-        kda_probs = calculations.calc_state_probs(G, key="val")
+        kda_probs = calculations.calc_state_probs(G)
 
         # generate the sympy functions for the state probabilities
-        sympy_funcs = calculations.calc_state_probs(G, key="name", output_strings=True)
+        sympy_funcs = calculations.calc_state_probs(G, output_strings=True)
         rate_names = [
             "k12",
             "k21",
@@ -532,7 +532,7 @@ class Test_Probability_Calcs:
         graph_utils.generate_edges(G, K)
 
         # calculate the state probabilities using KDA
-        kda_probs = calculations.calc_state_probs(G, key="val")
+        kda_probs = calculations.calc_state_probs(G)
 
         # use the ODE integrator to calculate the state probabilities
         probability_guess = np.array([1, 1, 1, 1, 1]) / 5
@@ -585,10 +585,10 @@ class Test_Probability_Calcs:
         graph_utils.generate_edges(G, K)
 
         # calculate the state probabilities using KDA
-        kda_probs = calculations.calc_state_probs(G, key="val")
+        kda_probs = calculations.calc_state_probs(G)
 
         # generate the sympy functions for the state probabilities
-        sympy_funcs = calculations.calc_state_probs(G, key="name", output_strings=True)
+        sympy_funcs = calculations.calc_state_probs(G, output_strings=True)
         rate_names = [
             "k12",
             "k21",
@@ -717,7 +717,6 @@ class Test_Flux_Diagrams:
             dirpar_edges=dirpar_edges,
             cycle=cycle,
             order=order,
-            key="val",
             output_strings=False,
         )
         # generate the net cycle flux function
@@ -726,7 +725,6 @@ class Test_Flux_Diagrams:
             dirpar_edges=dirpar_edges,
             cycle=cycle,
             order=order,
-            key="name",
             output_strings=True,
         )
         # convert sympy function into lambda function
@@ -768,11 +766,11 @@ class Test_Flux_Diagrams:
         order = [0, 1]
         # calculate the net cycle flux
         net_cycle_flux = calculations.calc_net_cycle_flux(
-            G, cycle=cycle, order=order, key="val", output_strings=False
+            G, cycle=cycle, order=order, output_strings=False
         )
         # generate the sympy net cycle flux function
         sympy_net_cycle_flux_func = calculations.calc_net_cycle_flux(
-            G, cycle=cycle, order=order, key="name", output_strings=True
+            G, cycle=cycle, order=order, output_strings=True
         )
         # make sure the sympy function agrees with the known solution
         expected_func = "(k12*k23*k31 - k13*k21*k32)/(k12*k23 + k12*k31 + k12*k32 + k13*k21 + k13*k23 + k13*k32 + k21*k31 + k21*k32 + k23*k31)"
@@ -956,7 +954,7 @@ class Test_Misc_Funcs:
 
         # calculate sigma_K value
         sigma_K_val = calculations.calc_sigma_K(
-            G, cycle, flux_diagrams, key="val", output_strings=False
+            G, cycle, flux_diagrams, output_strings=False
         )
         # check that the sigma_K value agrees with the known solution
         expected_value = k32 + k34
@@ -964,7 +962,7 @@ class Test_Misc_Funcs:
 
         # check that the sigma_K function agrees with the known solution
         sigma_K_func = calculations.calc_sigma_K(
-            G, cycle, flux_diagrams, key="name", output_strings=True
+            G, cycle, flux_diagrams, output_strings=True
         )
         expected_func = "k32+k34"
         assert sigma_K_func == expected_func
@@ -995,7 +993,7 @@ class Test_Misc_Funcs:
 
         # calculate the thermodynamic force
         thermo_force_val = calculations.calc_thermo_force(
-            G, cycle, cycle_order, key="val", output_strings=False
+            G, cycle, cycle_order, output_strings=False
         )
         if cycle == [0, 3, 2, 1]:
             expected_value = np.log(k12 * k23 * k34 * k41 / (k14 * k21 * k32 * k43))
@@ -1008,7 +1006,7 @@ class Test_Misc_Funcs:
         assert_allclose(thermo_force_val, expected_value, atol=1e-14, rtol=1e-14)
         # generate the equation for the thermodynamic force
         thermo_force_func = calculations.calc_thermo_force(
-            G, cycle, cycle_order, key="name", output_strings=True
+            G, cycle, cycle_order, output_strings=True
         )
         # check that the generated expression agrees with the expected function
         assert str(thermo_force_func) == str(thermo_force_func)
@@ -1212,65 +1210,6 @@ def test_get_ordered_cycle_all_node_cycles():
         calculations._get_ordered_cycle(G, invalid_cycle)
 
 
-def test_function_inputs():
-    # Tests the KDA API to make sure the appropriate errors are raised when
-    # users input incompatible combinations of parameters.
-
-    # create an adjacency matrix for a 4-state model with leakage
-    K = np.array([[0, 1, 0, 1], [1, 0, 1, 1], [0, 1, 0, 1], [1, 1, 1, 0]])
-    # generate the diagram and edges
-    G = nx.MultiDiGraph()
-    graph_utils.generate_edges(G, K)
-    # generate the directional partial diagrams
-    dirpar_edges = diagrams.generate_directional_diagrams(G, return_edges=True)
-
-    # test both cases for calc_sigma()
-    with pytest.raises(TypeError):
-        calculations.calc_sigma(G, dirpar_edges, key="name", output_strings=False)
-    with pytest.raises(TypeError):
-        calculations.calc_sigma(G, dirpar_edges, key="val", output_strings=True)
-
-    # pick one of the 3-node cycles and generate the flux diagrams for it
-    cycle = [0, 1, 3]
-    flux_diags = diagrams.generate_flux_diagrams(G, cycle)
-
-    # test both cases for calc_sigma_K
-    with pytest.raises(TypeError):
-        calculations.calc_sigma_K(
-            G, cycle, flux_diags, key="name", output_strings=False
-        )
-    with pytest.raises(TypeError):
-        calculations.calc_sigma_K(G, cycle, flux_diags, key="val", output_strings=True)
-
-    # pick the CCW direction
-    order = [0, 1]
-    # test both cases for calc_pi_difference()
-    with pytest.raises(TypeError):
-        calculations.calc_pi_difference(
-            G, cycle, order, key="name", output_strings=False
-        )
-    with pytest.raises(TypeError):
-        calculations.calc_pi_difference(G, cycle, order, key="val", output_strings=True)
-
-    # test both cases for calc_thermo_force()
-    with pytest.raises(TypeError):
-        calculations.calc_thermo_force(
-            G, cycle, order, key="name", output_strings=False
-        )
-    with pytest.raises(TypeError):
-        calculations.calc_thermo_force(G, cycle, order, key="val", output_strings=True)
-
-    # test both cases for calc_state_probs_from_diags()
-    with pytest.raises(TypeError):
-        calculations.calc_state_probs_from_diags(
-            G, dirpar_edges, key="name", output_strings=False
-        )
-    with pytest.raises(TypeError):
-        calculations.calc_state_probs_from_diags(
-            G, dirpar_edges, key="val", output_strings=True
-        )
-
-
 def test_retrieve_rate_matrix():
     # regression test for `graph_utils.retrieve_rate_matrix()`
     # checks that input and output rate matrices are the same
@@ -1311,7 +1250,7 @@ def test_add_attributes():
     graph_utils.generate_edges(G, K)
 
     # calculate the state probabilities using KDA
-    kda_probs = calculations.calc_state_probs(G, key="val")
+    kda_probs = calculations.calc_state_probs(G)
 
     node_data = kda_probs
     node_label = "probability"
@@ -1323,25 +1262,6 @@ def test_add_attributes():
     graph_label = "Graph rate matrix"
     graph_utils.add_graph_attribute(G, data=graph_data, label=graph_label)
     assert np.all(G.graph[graph_label] == K)
-
-
-def test_generate_edges_errors():
-    k_vals = np.array([[0, 1, 2], [5, 0, 6], [9, 10, 0],])
-    k_names = np.array(
-        [["k11", "k12", "k13"], ["k21", "k22", "k23"], ["k31", "k32", "k33"],]
-    )
-
-    # initialize graph object
-    G = nx.MultiDiGraph()
-    graph_utils.generate_edges(G, vals=k_vals, names=k_names)
-
-    G = nx.MultiDiGraph()
-    with pytest.raises(TypeError):
-        graph_utils.generate_edges(G, vals=k_names, names=k_names)
-
-    G = nx.MultiDiGraph()
-    with pytest.raises(TypeError):
-        graph_utils.generate_edges(G, vals=k_vals, names=k_vals)
 
 
 def test_ccw():


### PR DESCRIPTION
## Description

* Remove the `key` and `names` parameters from 
all functions in `calculations.py`. Edge
weights are now stored under a standard
attribute name `weight`. For functions
requiring the variable names (i.e. "k12") the
strings are simply created on the fly using
the available edge data.

* Remove checks in `calculations.py` functions 
for `key`/`output_strings` mismatches as well
as the test, `test_kda.test_function_inputs`, which
checked `TypeError`s were raised at appropriate
times

* Remove `names`, `val_key`, `name_key` parameters from
`graph_utils.generate_edges`, as well as the associate test
`test_generate_edges_errors` which checked the input
parameters raised `TypeErrors` at appropriate times

* Remove `graph_utils.generate_K_string_matrix`
since it is no longer necessary for generating
kinetic diagrams

* Update documentation for all functions
to reflect parameter changes

* Fix `diagrams.enumerate_partial_diagrams` to build
the adjacency matrix without retrieving the edge 
weights from the diagram

* Update `graph_utils.retrieve_rate_matrix`
to use `NetworkX.to_numpy_array`

* Update function calls in `test_kda.py`
to reflect parameter changes

* Fix issue #56

## Status
- [x] Ready to go