### PR TITLE
ENH: Optimize state probability expression parsing

### DIFF
--- a/kda/calculations.py
+++ b/kda/calculations.py
@@ -419,17 +419,12 @@ def calc_state_probs(G, key, output_strings=False):
         List of analytic SymPy state probability functions.
     """
     dirpar_edges = diagrams.generate_directional_diagrams(G, return_edges=True)
-    if output_strings == False:
-        state_probs = calc_state_probs_from_diags(
-            G, dirpar_edges, key, output_strings=output_strings
-        )
-        return state_probs
-    if output_strings == True:
-        state_mults, norm = calc_state_probs_from_diags(
-            G, dirpar_edges, key, output_strings=output_strings
-        )
-        state_probs_sympy = expressions.construct_sympy_prob_funcs(state_mults, norm)
-        return state_probs_sympy
+    state_probs = calc_state_probs_from_diags(
+        G, dirpar_edges=dirpar_edges, key=key, output_strings=output_strings,
+    )
+    if output_strings:
+        state_probs = expressions.construct_sympy_prob_funcs(state_mult_funcs=state_probs)
+    return state_probs
 
 
 def calc_net_cycle_flux(G, cycle, order, key, output_strings=False):
@@ -567,9 +562,7 @@ def calc_state_probs_from_diags(G, dirpar_edges, key, output_strings=False):
         dirpar_rate_products = dirpar_rate_products.reshape(n_states, n_partials)
         for i, arr in enumerate(dirpar_rate_products):
             state_mults[i] = "+".join(arr)
-        # sum all terms to get normalization factor
-        norm = "+".join(state_mults)
-        return state_mults, norm
+        return state_mults
 
 
 def calc_net_cycle_flux_from_diags(

--- a/kda/expressions.py
+++ b/kda/expressions.py
@@ -19,7 +19,7 @@ from sympy import lambdify, Mul
 from sympy.parsing.sympy_parser import parse_expr
 
 
-def construct_sympy_prob_funcs(state_mult_funcs, norm_func):
+def construct_sympy_prob_funcs(state_mult_funcs):
     """
     Constructs analytic state probability SymPy functions
 
@@ -37,12 +37,14 @@ def construct_sympy_prob_funcs(state_mult_funcs, norm_func):
     sympy_funcs : list
         List of analytic state probability SymPy functions.
     """
-    sympy_funcs = []  # create empty list to fill with state probability functions
-    for func in state_mult_funcs:
-        # convert strings into SymPy functions, normalize
-        prob_func = parse_expr(func) / parse_expr(norm_func)
-        sympy_funcs.append(prob_func)
-    return sympy_funcs
+    # convert the state multiplicity strings into sympy expressions
+    parsed_mult_funcs = [parse_expr(e) for e in state_mult_funcs]
+    # create the normalization expression
+    parsed_sigma = sum(parsed_mult_funcs)
+    # normalize the multiplicity expressions
+    prob_funcs = [e/parsed_sigma for e in parsed_mult_funcs]
+    return prob_funcs
+
 
 
 def construct_sympy_net_cycle_flux_func(pi_diff_str, sigma_K_str, sigma_str):


### PR DESCRIPTION
## Description
I found a rather obvious performance optimization regarding expression parsing with `sympy`. At a high level, we were parsing the same terms in state probability expressions multiple times. This was due to expressions being normalized _before_ parsing, so `sympy` was parsing each state multiplicity + the normalization expression (the sum of all multiplicity expressions) for each state.

For a diagram with `N` states, there are `N*P` terms, where `P` is the number of partial diagrams. This means we have to parse `N*N*P` terms to generate _all_ probability expressions. With the current algorithm, we are parsing `N*(N*P + N*N*P)` terms, which means we are parsing `N+1`x the number of terms we need to.

To quantify the real world performance difference, I wrote a short script which times the generation of symbolic state probability expressions:
<details><summary>Testing script</summary>

```python
import os
import time
import pickle

from kda import calculations


def load_pickled_graph(path):
	"""
	Loads a pickled `NetworkX.MultiDiGraph` object
	"""
	with open(path, 'rb') as f:
		G = pickle.load(f)
	print(f"Loaded {os.path.basename(path)} -- {G}")
	return G


def main():
	graph_paths = [
		os.path.abspath("./graph_3_1.pk"),
		os.path.abspath("./graph_4_1.pk"),
		os.path.abspath("./graph_5_1.pk"),
		os.path.abspath("./graph_6_9.pk"),
		os.path.abspath("./graph_7_17.pk"),
	]

	graphs = []
	times = []
	for path in graph_paths:
		G = load_pickled_graph(path=path)
		start = time.time()
		prob_exprs = calculations.calc_state_probs(G=G, key="name", output_strings=True)
		runtime = time.time() - start
		graphs.append(os.path.basename(path))
		times.append(runtime)

	print(f"\nRuntime to generate all state probability expressions")
	print("-" * 40)
	for g, t in zip(graphs, times):
		print(f"{g}:  {t:.3f} s")


if __name__ == "__main__":
	main()
```
</details>

Comparing the runtimes on `master` vs. `optimize_prob_expr_parsing`:

```
Graph             master      optimize_prob_expr_parsing
--------------------------------------------------------
graph_3_1         0.094 s           0.062 s
graph_4_1         0.047 s           0.047 s
graph_5_1         0.375 s           0.145 s
graph_6_9         8.274 s           0.837 s
graph_7_17       18.990 s           1.743 s
```

We don't see a large speedup for the smaller models as the parsing is likely a small % of the runtime for those cases. But for the 6 and 7-state cases, we see a **9.9x** and **10.9x**, respectively.


## Changes
* Changes the way state multiplicity expressions are summed by first parsing them with `sympy`, then combining them using `sum()`. This way we only have to parse each term a single time instead of `N+1` times. This offers a significant speedup for complex diagrams, especially those with many states.

## Status
- [x] Ready to go