### PR TITLE
TST: Create conftest.py, move state prob fixtures

### DIFF
--- a/kda/tests/conftest.py
+++ b/kda/tests/conftest.py
@@ -1,0 +1,209 @@
+# Nikolaus Awtrey
+# Beckstein Lab
+# Department of Physics
+# Arizona State University
+#
+# Kinetic Diagram Analysis Testing Fixtures
+
+import pytest
+import numpy as np
+
+
+@pytest.fixture(scope="class")
+def state_probs_3_state():
+	def _state_probs(k12, k21, k23, k32, k13, k31):
+	    P1 = k23 * k31 + k32 * k21 + k31 * k21
+	    P2 = k13 * k32 + k32 * k12 + k31 * k12
+	    P3 = k13 * k23 + k12 * k23 + k21 * k13
+	    Sigma = P1 + P2 + P3  # Normalization factor
+	    return np.array([P1, P2, P3]) / Sigma
+	return _state_probs
+
+
+@pytest.fixture(scope="class")
+def state_probs_4_state():
+	def _state_probs(k12, k21, k23, k32, k34, k43, k41, k14):
+	    P1 = k43 * k32 * k21 + k23 * k34 * k41 + k21 * k34 * k41 + k41 * k32 * k21
+	    P2 = k12 * k43 * k32 + k14 * k43 * k32 + k34 * k41 * k12 + k32 * k41 * k12
+	    P3 = k43 * k12 * k23 + k23 * k14 * k43 + k21 * k14 * k43 + k41 * k12 * k23
+	    P4 = k12 * k23 * k34 + k14 * k23 * k34 + k34 * k21 * k14 + k32 * k21 * k14
+	    Sigma = P1 + P2 + P3 + P4  # Normalization factor
+	    return np.array([P1, P2, P3, P4]) / Sigma
+	return _state_probs
+
+
+@pytest.fixture(scope="class")
+def state_probs_4wl():
+	def _state_probs(k12, k21, k23, k32, k34, k43, k41, k14, k24, k42):
+		P1 = (
+            k43 * k32 * k21
+            + k23 * k34 * k41
+            + k21 * k34 * k41
+            + k41 * k32 * k21
+            + k32 * k42 * k21
+            + k24 * k34 * k41
+            + k34 * k42 * k21
+            + k32 * k24 * k41
+        )
+		P2 = (
+            k12 * k43 * k32
+            + k14 * k43 * k32
+            + k34 * k41 * k12
+            + k32 * k41 * k12
+            + k32 * k42 * k12
+            + k34 * k14 * k42
+            + k12 * k34 * k42
+            + k32 * k14 * k42
+        )
+		P3 = (
+            k43 * k12 * k23
+            + k23 * k14 * k43
+            + k21 * k14 * k43
+            + k41 * k12 * k23
+            + k12 * k42 * k23
+            + k14 * k24 * k43
+            + k12 * k24 * k43
+            + k14 * k42 * k23
+        )
+		P4 = (
+            k12 * k23 * k34
+            + k14 * k23 * k34
+            + k34 * k21 * k14
+            + k32 * k21 * k14
+            + k32 * k12 * k24
+            + k14 * k24 * k34
+            + k34 * k12 * k24
+            + k14 * k32 * k24
+        )
+		Sigma = P1 + P2 + P3 + P4  # Normalization factor
+		return np.array([P1, P2, P3, P4]) / Sigma
+	return _state_probs
+
+
+@pytest.fixture(scope="class")
+def state_probs_5wl():
+	def _state_probs(k12, k21, k23, k32, k13, k31, k24, k42, k35, k53, k45, k54):
+		P1 = (
+			k35 * k54 * k42 * k21
+			+ k24 * k45 * k53 * k31
+			+ k21 * k45 * k53 * k31
+			+ k42 * k21 * k53 * k31
+			+ k54 * k42 * k21 * k31
+			+ k54 * k42 * k32 * k21
+			+ k45 * k53 * k23 * k31
+			+ k53 * k32 * k42 * k21
+			+ k42 * k23 * k53 * k31
+			+ k54 * k42 * k23 * k31
+			+ k45 * k53 * k32 * k21
+		)
+		P2 = (
+            k12 * k35 * k54 * k42
+            + k13 * k35 * k54 * k42
+            + k45 * k53 * k31 * k12
+            + k42 * k53 * k31 * k12
+            + k31 * k12 * k54 * k42
+            + k54 * k42 * k32 * k12
+            + k45 * k53 * k13 * k32
+            + k53 * k32 * k42 * k12
+            + k53 * k13 * k32 * k42
+            + k54 * k42 * k13 * k32
+            + k45 * k53 * k32 * k12
+        )
+		P3 = (
+            k12 * k24 * k45 * k53
+            + k13 * k24 * k45 * k53
+            + k21 * k13 * k45 * k53
+            + k42 * k21 * k13 * k53
+            + k54 * k42 * k21 * k13
+            + k54 * k42 * k12 * k23
+            + k45 * k53 * k23 * k13
+            + k42 * k12 * k23 * k53
+            + k42 * k23 * k13 * k53
+            + k54 * k42 * k23 * k13
+            + k45 * k53 * k12 * k23
+        )
+		P4 = (
+            k12 * k24 * k35 * k54
+            + k24 * k13 * k35 * k54
+            + k21 * k13 * k35 * k54
+            + k53 * k31 * k12 * k24
+            + k54 * k31 * k12 * k24
+            + k12 * k32 * k24 * k54
+            + k13 * k23 * k35 * k54
+            + k53 * k32 * k12 * k24
+            + k13 * k53 * k32 * k24
+            + k13 * k32 * k24 * k54
+            + k12 * k23 * k35 * k54
+        )
+		P5 = (
+            k35 * k12 * k24 * k45
+            + k13 * k35 * k24 * k45
+            + k45 * k21 * k13 * k35
+            + k42 * k21 * k13 * k35
+            + k31 * k12 * k24 * k45
+            + k12 * k32 * k24 * k45
+            + k13 * k23 * k35 * k45
+            + k12 * k42 * k23 * k35
+            + k42 * k23 * k13 * k35
+            + k13 * k32 * k24 * k45
+            + k12 * k23 * k35 * k45
+		)
+		Sigma = P1 + P2 + P3 + P4 + P5  # Normalization factor
+		return np.array([P1, P2, P3, P4, P5]) / Sigma
+	return _state_probs
+
+
+@pytest.fixture(scope="class")
+def state_probs_6_state():
+	def _state_probs(k12, k21, k23, k32, k34, k43, k45, k54, k56, k65, k61, k16):
+		P1 = (
+			k65 * k54 * k43 * k32 * k21
+			+ k61 * k54 * k43 * k32 * k21
+			+ k56 * k61 * k43 * k32 * k21
+			+ k45 * k56 * k61 * k32 * k21
+			+ k34 * k45 * k56 * k61 * k21
+			+ k23 * k34 * k45 * k56 * k61
+		)
+		P2 = (
+			k12 * k65 * k54 * k43 * k32
+			+ k61 * k12 * k54 * k43 * k32
+			+ k56 * k61 * k12 * k43 * k32
+			+ k45 * k56 * k61 * k32 * k12
+			+ k34 * k45 * k56 * k61 * k12
+			+ k16 * k65 * k54 * k43 * k32
+		)
+		P3 = (
+			k12 * k23 * k65 * k54 * k43
+			+ k61 * k12 * k23 * k54 * k43
+			+ k56 * k61 * k12 * k23 * k43
+			+ k45 * k56 * k61 * k12 * k23
+			+ k21 * k16 * k65 * k54 * k43
+			+ k23 * k16 * k65 * k54 * k43
+		)
+		P4 = (
+			k65 * k54 * k12 * k23 * k34
+			+ k54 * k61 * k12 * k23 * k34
+			+ k56 * k61 * k12 * k23 * k34
+			+ k32 * k21 * k16 * k65 * k54
+			+ k21 * k16 * k65 * k54 * k34
+			+ k16 * k65 * k54 * k23 * k34
+		)
+		P5 = (
+			k65 * k12 * k23 * k34 * k45
+			+ k61 * k12 * k23 * k34 * k45
+			+ k43 * k32 * k21 * k16 * k65
+			+ k45 * k32 * k21 * k16 * k65
+			+ k34 * k45 * k21 * k16 * k65
+			+ k23 * k34 * k45 * k16 * k65
+		)
+		P6 = (
+			k12 * k23 * k34 * k45 * k56
+			+ k54 * k43 * k32 * k21 * k16
+			+ k56 * k43 * k32 * k21 * k16
+			+ k45 * k56 * k32 * k21 * k16
+			+ k34 * k45 * k56 * k21 * k16
+			+ k16 * k23 * k34 * k45 * k56
+		)
+		Sigma = P1 + P2 + P3 + P4 + P5 + P6  # Normalization factor
+		return np.array([P1, P2, P3, P4, P5, P6]) / Sigma
+	return _state_probs

--- a/kda/tests/test_kda.py
+++ b/kda/tests/test_kda.py
@@ -14,240 +14,23 @@ from kda import calculations, diagrams, graph_utils, expressions, ode, svd
 from kda.exceptions import CycleError
 
 
-class StateProbs3:
-    def __init__(self, k_vals):
-        self.k_vals = k_vals
-
-    def return_probs(self, k12, k21, k23, k32, k13, k31):
-        P1 = k23 * k31 + k32 * k21 + k31 * k21
-        P2 = k13 * k32 + k32 * k12 + k31 * k12
-        P3 = k13 * k23 + k12 * k23 + k21 * k13
-        Sigma = P1 + P2 + P3  # Normalization factor
-        return np.array([P1, P2, P3]) / Sigma
-
-
-class StateProbs4:
-    def __init__(self, k_vals):
-        self.k_vals = k_vals
-
-    def return_probs(self, k12, k21, k23, k32, k34, k43, k41, k14):
-        P1 = k43 * k32 * k21 + k23 * k34 * k41 + k21 * k34 * k41 + k41 * k32 * k21
-        P2 = k12 * k43 * k32 + k14 * k43 * k32 + k34 * k41 * k12 + k32 * k41 * k12
-        P3 = k43 * k12 * k23 + k23 * k14 * k43 + k21 * k14 * k43 + k41 * k12 * k23
-        P4 = k12 * k23 * k34 + k14 * k23 * k34 + k34 * k21 * k14 + k32 * k21 * k14
-        Sigma = P1 + P2 + P3 + P4  # Normalization factor
-        return np.array([P1, P2, P3, P4]) / Sigma
-
-
-class StateProbs4WL:
-    def __init__(self, k_vals):
-        self.k_vals = k_vals
-
-    def return_probs(self, k12, k21, k23, k32, k34, k43, k41, k14, k24, k42):
-        P1 = (
-            k43 * k32 * k21
-            + k23 * k34 * k41
-            + k21 * k34 * k41
-            + k41 * k32 * k21
-            + k32 * k42 * k21
-            + k24 * k34 * k41
-            + k34 * k42 * k21
-            + k32 * k24 * k41
-        )
-        P2 = (
-            k12 * k43 * k32
-            + k14 * k43 * k32
-            + k34 * k41 * k12
-            + k32 * k41 * k12
-            + k32 * k42 * k12
-            + k34 * k14 * k42
-            + k12 * k34 * k42
-            + k32 * k14 * k42
-        )
-        P3 = (
-            k43 * k12 * k23
-            + k23 * k14 * k43
-            + k21 * k14 * k43
-            + k41 * k12 * k23
-            + k12 * k42 * k23
-            + k14 * k24 * k43
-            + k12 * k24 * k43
-            + k14 * k42 * k23
-        )
-        P4 = (
-            k12 * k23 * k34
-            + k14 * k23 * k34
-            + k34 * k21 * k14
-            + k32 * k21 * k14
-            + k32 * k12 * k24
-            + k14 * k24 * k34
-            + k34 * k12 * k24
-            + k14 * k32 * k24
-        )
-        Sigma = P1 + P2 + P3 + P4  # Normalization factor
-        return np.array([P1, P2, P3, P4]) / Sigma
-
-
-class StateProbs5WL:
-    def __init__(self, k_vals):
-        self.k_vals = k_vals
-
-    def return_probs(self, k12, k21, k23, k32, k13, k31, k24, k42, k35, k53, k45, k54):
-        P1 = (
-            k35 * k54 * k42 * k21
-            + k24 * k45 * k53 * k31
-            + k21 * k45 * k53 * k31
-            + k42 * k21 * k53 * k31
-            + k54 * k42 * k21 * k31
-            + k54 * k42 * k32 * k21
-            + k45 * k53 * k23 * k31
-            + k53 * k32 * k42 * k21
-            + k42 * k23 * k53 * k31
-            + k54 * k42 * k23 * k31
-            + k45 * k53 * k32 * k21
-        )
-        P2 = (
-            k12 * k35 * k54 * k42
-            + k13 * k35 * k54 * k42
-            + k45 * k53 * k31 * k12
-            + k42 * k53 * k31 * k12
-            + k31 * k12 * k54 * k42
-            + k54 * k42 * k32 * k12
-            + k45 * k53 * k13 * k32
-            + k53 * k32 * k42 * k12
-            + k53 * k13 * k32 * k42
-            + k54 * k42 * k13 * k32
-            + k45 * k53 * k32 * k12
-        )
-        P3 = (
-            k12 * k24 * k45 * k53
-            + k13 * k24 * k45 * k53
-            + k21 * k13 * k45 * k53
-            + k42 * k21 * k13 * k53
-            + k54 * k42 * k21 * k13
-            + k54 * k42 * k12 * k23
-            + k45 * k53 * k23 * k13
-            + k42 * k12 * k23 * k53
-            + k42 * k23 * k13 * k53
-            + k54 * k42 * k23 * k13
-            + k45 * k53 * k12 * k23
-        )
-        P4 = (
-            k12 * k24 * k35 * k54
-            + k24 * k13 * k35 * k54
-            + k21 * k13 * k35 * k54
-            + k53 * k31 * k12 * k24
-            + k54 * k31 * k12 * k24
-            + k12 * k32 * k24 * k54
-            + k13 * k23 * k35 * k54
-            + k53 * k32 * k12 * k24
-            + k13 * k53 * k32 * k24
-            + k13 * k32 * k24 * k54
-            + k12 * k23 * k35 * k54
-        )
-        P5 = (
-            k35 * k12 * k24 * k45
-            + k13 * k35 * k24 * k45
-            + k45 * k21 * k13 * k35
-            + k42 * k21 * k13 * k35
-            + k31 * k12 * k24 * k45
-            + k12 * k32 * k24 * k45
-            + k13 * k23 * k35 * k45
-            + k12 * k42 * k23 * k35
-            + k42 * k23 * k13 * k35
-            + k13 * k32 * k24 * k45
-            + k12 * k23 * k35 * k45
-        )
-        Sigma = P1 + P2 + P3 + P4 + P5  # Normalization factor
-        return np.array([P1, P2, P3, P4, P5]) / Sigma
-
-
-class StateProbs6:
-    def __init__(self, k_vals):
-        self.k_vals = k_vals
-
-    def return_probs(self, k12, k21, k23, k32, k34, k43, k45, k54, k56, k65, k61, k16):
-        P1 = (
-            k65 * k54 * k43 * k32 * k21
-            + k61 * k54 * k43 * k32 * k21
-            + k56 * k61 * k43 * k32 * k21
-            + k45 * k56 * k61 * k32 * k21
-            + k34 * k45 * k56 * k61 * k21
-            + k23 * k34 * k45 * k56 * k61
-        )
-        P2 = (
-            k12 * k65 * k54 * k43 * k32
-            + k61 * k12 * k54 * k43 * k32
-            + k56 * k61 * k12 * k43 * k32
-            + k45 * k56 * k61 * k32 * k12
-            + k34 * k45 * k56 * k61 * k12
-            + k16 * k65 * k54 * k43 * k32
-        )
-        P3 = (
-            k12 * k23 * k65 * k54 * k43
-            + k61 * k12 * k23 * k54 * k43
-            + k56 * k61 * k12 * k23 * k43
-            + k45 * k56 * k61 * k12 * k23
-            + k21 * k16 * k65 * k54 * k43
-            + k23 * k16 * k65 * k54 * k43
-        )
-        P4 = (
-            k65 * k54 * k12 * k23 * k34
-            + k54 * k61 * k12 * k23 * k34
-            + k56 * k61 * k12 * k23 * k34
-            + k32 * k21 * k16 * k65 * k54
-            + k21 * k16 * k65 * k54 * k34
-            + k16 * k65 * k54 * k23 * k34
-        )
-        P5 = (
-            k65 * k12 * k23 * k34 * k45
-            + k61 * k12 * k23 * k34 * k45
-            + k43 * k32 * k21 * k16 * k65
-            + k45 * k32 * k21 * k16 * k65
-            + k34 * k45 * k21 * k16 * k65
-            + k23 * k34 * k45 * k16 * k65
-        )
-        P6 = (
-            k12 * k23 * k34 * k45 * k56
-            + k54 * k43 * k32 * k21 * k16
-            + k56 * k43 * k32 * k21 * k16
-            + k45 * k56 * k32 * k21 * k16
-            + k34 * k45 * k56 * k21 * k16
-            + k16 * k23 * k34 * k45 * k56
-        )
-        Sigma = P1 + P2 + P3 + P4 + P5 + P6  # Normalization factor
-        return np.array([P1, P2, P3, P4, P5, P6]) / Sigma
-
-
+@pytest.mark.usefixtures(
+    "state_probs_3_state",
+    "state_probs_4_state",
+    "state_probs_4wl",
+    "state_probs_5wl",
+    "state_probs_6_state",
+    )
 class Test_Probability_Calcs:
-    @pytest.fixture(scope="class")
-    def SP3(k_vals):
-        return StateProbs3(k_vals)
-
-    @pytest.fixture(scope="class")
-    def SP4(k_vals):
-        return StateProbs4(k_vals)
-
-    @pytest.fixture(scope="class")
-    def SP4WL(k_vals):
-        return StateProbs4WL(k_vals)
-
-    @pytest.fixture(scope="class")
-    def SP5WL(k_vals):
-        return StateProbs5WL(k_vals)
-
-    @pytest.fixture(scope="class")
-    def SP6(k_vals):
-        return StateProbs6(k_vals)
 
     @settings(deadline=None)
     @given(
         k_vals=st.lists(st.floats(min_value=1, max_value=10), min_size=6, max_size=6),
     )
-    def test_3_state_probs(self, k_vals, SP3):
+    def test_3_state_probs(self, k_vals, state_probs_3_state):
         # assign the rates accordingly
         k12, k21, k23, k32, k13, k31 = k_vals
-        expected_probs = SP3.return_probs(k12, k21, k23, k32, k13, k31)
+        expected_probs = state_probs_3_state(k12, k21, k23, k32, k13, k31)
 
         K = np.array([[0, k12, k13], [k21, 0, k23], [k31, k32, 0]])
         # generate the diagram and edges
@@ -300,10 +83,10 @@ class Test_Probability_Calcs:
     @given(
         k_vals=st.lists(st.floats(min_value=1, max_value=10), min_size=8, max_size=8),
     )
-    def test_4_state_probs(self, k_vals, SP4):
+    def test_4_state_probs(self, k_vals, state_probs_4_state):
         # assign the rates accordingly
         k12, k21, k23, k32, k34, k43, k41, k14 = k_vals
-        expected_probs = SP4.return_probs(k12, k21, k23, k32, k34, k43, k41, k14)
+        expected_probs = state_probs_4_state(k12, k21, k23, k32, k34, k43, k41, k14)
 
         K = np.array(
             [[0, k12, 0, k14], [k21, 0, k23, 0], [0, k32, 0, k34], [k41, 0, k43, 0]]
@@ -358,10 +141,10 @@ class Test_Probability_Calcs:
     @given(
         k_vals=st.lists(st.floats(min_value=1, max_value=10), min_size=10, max_size=10),
     )
-    def test_4_state_probs_with_leakage(self, k_vals, SP4WL):
+    def test_4_state_probs_with_leakage(self, k_vals, state_probs_4wl):
         # assign the rates accordingly
         (k12, k21, k23, k32, k34, k43, k41, k14, k24, k42) = k_vals
-        expected_probs = SP4WL.return_probs(
+        expected_probs = state_probs_4wl(
             k12, k21, k23, k32, k34, k43, k41, k14, k24, k42
         )
 
@@ -431,10 +214,10 @@ class Test_Probability_Calcs:
     @given(
         k_vals=st.lists(st.floats(min_value=1, max_value=10), min_size=12, max_size=12),
     )
-    def test_5_state_probs_with_leakage(self, k_vals, SP5WL):
+    def test_5_state_probs_with_leakage(self, k_vals, state_probs_5wl):
         # assign the rates accordingly
         (k12, k21, k23, k32, k13, k31, k24, k42, k35, k53, k45, k54) = k_vals
-        expected_probs = SP5WL.return_probs(
+        expected_probs = state_probs_5wl(
             k12, k21, k23, k32, k13, k31, k24, k42, k35, k53, k45, k54
         )
 
@@ -511,10 +294,10 @@ class Test_Probability_Calcs:
     @pytest.mark.parametrize(
         "k_vals", [(1e5, 2e-4, 5e-8, 5e-8, 1e5, 2e-4, 6, 4e8, 3e-8, 4e8, 3e-8, 6)]
     )
-    def test_5wl_state_probs_bad_apple(self, k_vals, SP5WL):
+    def test_5wl_state_probs_bad_apple(self, k_vals, state_probs_5wl):
         # assign the rates accordingly
         (k12, k21, k23, k32, k13, k31, k24, k42, k35, k53, k45, k54) = k_vals
-        expected_probs = SP5WL.return_probs(
+        expected_probs = state_probs_5wl(
             k12, k21, k23, k32, k13, k31, k24, k42, k35, k53, k45, k54
         )
 
@@ -563,10 +346,10 @@ class Test_Probability_Calcs:
     @given(
         k_vals=st.lists(st.floats(min_value=1, max_value=10), min_size=12, max_size=12),
     )
-    def test_6_state_probs(self, k_vals, SP6):
+    def test_6_state_probs(self, k_vals, state_probs_6_state):
         # assign the rates accordingly
         (k12, k21, k23, k32, k34, k43, k45, k54, k56, k65, k61, k16) = k_vals
-        expected_probs = SP6.return_probs(
+        expected_probs = state_probs_6_state(
             k12, k21, k23, k32, k34, k43, k45, k54, k56, k65, k61, k16
         )
 


### PR DESCRIPTION
* Adds a `conftest.py` for storing testing fixtures for use generally across all tests. Eventually
we might add fixtures for generating the commonly
used kinetic diagrams (3-state, 4-state, etc.)
to simplify tests in the long run.

* Moves hardcoded state probability functions to `conftest.py` with `scope="class"` so they
are only created once

* Fixes #31