### PR TITLE
TST: Add sympy expression fixtures

### DIFF
--- a/kda/tests/conftest.py
+++ b/kda/tests/conftest.py
@@ -7,6 +7,9 @@
 
 import pytest
 import numpy as np
+import networkx as nx
+
+from kda import graph_utils, calculations
 
 
 @pytest.fixture(scope="class")
@@ -21,6 +24,15 @@ def state_probs_3_state():
 
 
 @pytest.fixture(scope="class")
+def symbolic_state_probs_3_state():
+	K = np.array([[0, 1, 1], [1, 0, 1], [1, 1, 0]])
+	G = nx.MultiDiGraph()
+	graph_utils.generate_edges(G, K)
+	sympy_funcs = calculations.calc_state_probs(G, key="name", output_strings=True)
+	return sympy_funcs
+
+
+@pytest.fixture(scope="class")
 def state_probs_4_state():
 	def _state_probs(k12, k21, k23, k32, k34, k43, k41, k14):
 	    P1 = k43 * k32 * k21 + k23 * k34 * k41 + k21 * k34 * k41 + k41 * k32 * k21
@@ -30,6 +42,20 @@ def state_probs_4_state():
 	    Sigma = P1 + P2 + P3 + P4  # Normalization factor
 	    return np.array([P1, P2, P3, P4]) / Sigma
 	return _state_probs
+
+
+@pytest.fixture(scope="class")
+def symbolic_state_probs_4_state():
+	K = np.array([
+		[0, 1, 0, 1],
+		[1, 0, 1, 0],
+		[0, 1, 0, 1],
+		[1, 0, 1, 0],
+	])
+	G = nx.MultiDiGraph()
+	graph_utils.generate_edges(G, K)
+	sympy_funcs = calculations.calc_state_probs(G, key="name", output_strings=True)
+	return sympy_funcs
 
 
 @pytest.fixture(scope="class")
@@ -78,6 +104,20 @@ def state_probs_4wl():
 		Sigma = P1 + P2 + P3 + P4  # Normalization factor
 		return np.array([P1, P2, P3, P4]) / Sigma
 	return _state_probs
+
+
+@pytest.fixture(scope="class")
+def symbolic_state_probs_4wl():
+	K = np.array([
+		[0, 1, 0, 1],
+		[1, 0, 1, 1],
+		[0, 1, 0, 1],
+		[1, 1, 1, 0],
+	])
+	G = nx.MultiDiGraph()
+	graph_utils.generate_edges(G, K)
+	sympy_funcs = calculations.calc_state_probs(G, key="name", output_strings=True)
+	return sympy_funcs
 
 
 @pytest.fixture(scope="class")
@@ -154,6 +194,21 @@ def state_probs_5wl():
 
 
 @pytest.fixture(scope="class")
+def symbolic_state_probs_5wl():
+	K = np.array([
+		[0, 1, 1, 0, 0],
+		[1, 0, 1, 1, 0],
+		[1, 1, 0, 0, 1],
+		[0, 1, 0, 0, 1],
+		[0, 0, 1, 1, 0],
+	])
+	G = nx.MultiDiGraph()
+	graph_utils.generate_edges(G, K)
+	sympy_funcs = calculations.calc_state_probs(G, key="name", output_strings=True)
+	return sympy_funcs
+
+
+@pytest.fixture(scope="class")
 def state_probs_6_state():
 	def _state_probs(k12, k21, k23, k32, k34, k43, k45, k54, k56, k65, k61, k16):
 		P1 = (
@@ -207,3 +262,19 @@ def state_probs_6_state():
 		Sigma = P1 + P2 + P3 + P4 + P5 + P6  # Normalization factor
 		return np.array([P1, P2, P3, P4, P5, P6]) / Sigma
 	return _state_probs
+
+
+@pytest.fixture(scope="class")
+def symbolic_state_probs_6_state():
+	K = np.array([
+		[0, 1, 0, 0, 0, 1],
+		[1, 0, 1, 0, 0, 0],
+		[0, 1, 0, 1, 0, 0],
+		[0, 0, 1, 0, 1, 0],
+		[0, 0, 0, 1, 0, 1],
+		[1, 0, 0, 0, 1, 0],
+	])
+	G = nx.MultiDiGraph()
+	graph_utils.generate_edges(G, K)
+	sympy_funcs = calculations.calc_state_probs(G, key="name", output_strings=True)
+	return sympy_funcs

--- a/kda/tests/test_kda.py
+++ b/kda/tests/test_kda.py
@@ -16,10 +16,15 @@ from kda.exceptions import CycleError
 
 @pytest.mark.usefixtures(
     "state_probs_3_state",
+    "symbolic_state_probs_3_state",
     "state_probs_4_state",
+    "symbolic_state_probs_4_state",
     "state_probs_4wl",
+    "symbolic_state_probs_4wl",
     "state_probs_5wl",
+    "symbolic_state_probs_5wl",
     "state_probs_6_state",
+    "symbolic_state_probs_6_state",
     )
 class Test_Probability_Calcs:
 
@@ -27,7 +32,7 @@ class Test_Probability_Calcs:
     @given(
         k_vals=st.lists(st.floats(min_value=1, max_value=10), min_size=6, max_size=6),
     )
-    def test_3_state_probs(self, k_vals, state_probs_3_state):
+    def test_3_state_probs(self, k_vals, state_probs_3_state, symbolic_state_probs_3_state):
         # assign the rates accordingly
         k12, k21, k23, k32, k13, k31 = k_vals
         expected_probs = state_probs_3_state(k12, k21, k23, k32, k13, k31)
@@ -41,10 +46,9 @@ class Test_Probability_Calcs:
         kda_probs = calculations.calc_state_probs(G, key="val", output_strings=False)
 
         # generate the sympy functions for the state probabilities
-        sympy_funcs = calculations.calc_state_probs(G, key="name", output_strings=True)
         rate_names = ["k12", "k21", "k23", "k32", "k13", "k31"]
         sympy_prob_funcs = expressions.construct_lambda_funcs(
-            sympy_funcs=sympy_funcs, rate_names=rate_names
+            sympy_funcs=symbolic_state_probs_3_state, rate_names=rate_names
         )
 
         # use the functions to calculate the state probabilities
@@ -83,7 +87,7 @@ class Test_Probability_Calcs:
     @given(
         k_vals=st.lists(st.floats(min_value=1, max_value=10), min_size=8, max_size=8),
     )
-    def test_4_state_probs(self, k_vals, state_probs_4_state):
+    def test_4_state_probs(self, k_vals, state_probs_4_state, symbolic_state_probs_4_state):
         # assign the rates accordingly
         k12, k21, k23, k32, k34, k43, k41, k14 = k_vals
         expected_probs = state_probs_4_state(k12, k21, k23, k32, k34, k43, k41, k14)
@@ -99,10 +103,9 @@ class Test_Probability_Calcs:
         kda_probs = calculations.calc_state_probs(G, key="val", output_strings=False)
 
         # generate the sympy functions for the state probabilities
-        sympy_funcs = calculations.calc_state_probs(G, key="name", output_strings=True)
         rate_names = ["k12", "k21", "k23", "k32", "k34", "k43", "k41", "k14"]
         sympy_prob_funcs = expressions.construct_lambda_funcs(
-            sympy_funcs=sympy_funcs, rate_names=rate_names
+            sympy_funcs=symbolic_state_probs_4_state, rate_names=rate_names
         )
 
         # use the functions to calculate the state probabilities
@@ -141,7 +144,7 @@ class Test_Probability_Calcs:
     @given(
         k_vals=st.lists(st.floats(min_value=1, max_value=10), min_size=10, max_size=10),
     )
-    def test_4_state_probs_with_leakage(self, k_vals, state_probs_4wl):
+    def test_4_state_probs_with_leakage(self, k_vals, state_probs_4wl, symbolic_state_probs_4wl):
         # assign the rates accordingly
         (k12, k21, k23, k32, k34, k43, k41, k14, k24, k42) = k_vals
         expected_probs = state_probs_4wl(
@@ -159,21 +162,11 @@ class Test_Probability_Calcs:
         kda_probs = calculations.calc_state_probs(G, key="val", output_strings=False)
 
         # generate the sympy functions for the state probabilities
-        sympy_funcs = calculations.calc_state_probs(G, key="name", output_strings=True)
         rate_names = [
-            "k12",
-            "k21",
-            "k23",
-            "k32",
-            "k34",
-            "k43",
-            "k41",
-            "k14",
-            "k24",
-            "k42",
-        ]
+            "k12", "k21", "k23", "k32", "k34", "k43", "k41", "k14", "k24", "k42",
+            ]
         sympy_prob_funcs = expressions.construct_lambda_funcs(
-            sympy_funcs=sympy_funcs, rate_names=rate_names
+            sympy_funcs=symbolic_state_probs_4wl, rate_names=rate_names
         )
 
         # use the functions to calculate the state probabilities
@@ -214,7 +207,7 @@ class Test_Probability_Calcs:
     @given(
         k_vals=st.lists(st.floats(min_value=1, max_value=10), min_size=12, max_size=12),
     )
-    def test_5_state_probs_with_leakage(self, k_vals, state_probs_5wl):
+    def test_5_state_probs_with_leakage(self, k_vals, state_probs_5wl, symbolic_state_probs_5wl):
         # assign the rates accordingly
         (k12, k21, k23, k32, k13, k31, k24, k42, k35, k53, k45, k54) = k_vals
         expected_probs = state_probs_5wl(
@@ -238,23 +231,12 @@ class Test_Probability_Calcs:
         kda_probs = calculations.calc_state_probs(G, key="val", output_strings=False)
 
         # generate the sympy functions for the state probabilities
-        sympy_funcs = calculations.calc_state_probs(G, key="name", output_strings=True)
         rate_names = [
-            "k12",
-            "k21",
-            "k23",
-            "k32",
-            "k13",
-            "k31",
-            "k24",
-            "k42",
-            "k35",
-            "k53",
-            "k45",
-            "k54",
+            "k12", "k21", "k23", "k32", "k13", "k31",
+            "k24", "k42", "k35", "k53", "k45", "k54",
         ]
         sympy_prob_funcs = expressions.construct_lambda_funcs(
-            sympy_funcs=sympy_funcs, rate_names=rate_names
+            sympy_funcs=symbolic_state_probs_5wl, rate_names=rate_names
         )
 
         # use the functions to calculate the state probabilities
@@ -346,7 +328,7 @@ class Test_Probability_Calcs:
     @given(
         k_vals=st.lists(st.floats(min_value=1, max_value=10), min_size=12, max_size=12),
     )
-    def test_6_state_probs(self, k_vals, state_probs_6_state):
+    def test_6_state_probs(self, k_vals, state_probs_6_state, symbolic_state_probs_6_state):
         # assign the rates accordingly
         (k12, k21, k23, k32, k34, k43, k45, k54, k56, k65, k61, k16) = k_vals
         expected_probs = state_probs_6_state(
@@ -371,23 +353,12 @@ class Test_Probability_Calcs:
         kda_probs = calculations.calc_state_probs(G, key="val", output_strings=False)
 
         # generate the sympy functions for the state probabilities
-        sympy_funcs = calculations.calc_state_probs(G, key="name", output_strings=True)
         rate_names = [
-            "k12",
-            "k21",
-            "k23",
-            "k32",
-            "k34",
-            "k43",
-            "k45",
-            "k54",
-            "k56",
-            "k65",
-            "k61",
-            "k16",
+            "k12", "k21", "k23", "k32", "k34", "k43",
+            "k45", "k54", "k56", "k65", "k61", "k16",
         ]
         sympy_prob_funcs = expressions.construct_lambda_funcs(
-            sympy_funcs=sympy_funcs, rate_names=rate_names
+            sympy_funcs=symbolic_state_probs_6_state, rate_names=rate_names
         )
 
         # use the functions to calculate the state probabilities


### PR DESCRIPTION
## Description
The state probability expression tests in `test_kda.py` use `hypothesis` to run over various randomly generated data sets. For each test model, we currently calculate the state probabilities using manually typed expression fixtures, KDA (numeric), KDA (symbolic), the KDA matrix solver, the KDA SVD solver, and the KDA ODE solver. Of these different evaluations, the KDA symbolic and KDA ODE solver seem to be the primary contributors to the test run time, and the state probability tests are roughly 50% of the overall test suite run time. 

In the interest of test suite performance, I decided to add some fixtures for generating the KDA symbolic state probability expressions so they only have to be created once for the entire class. After implementing the new fixtures, it looks like we have only reduce the test suite run time by ~7 seconds out of ~67 on `master`. I was hoping for a little better increase but I'll take it.

## Changes

* Adds fixtures to `conftest.py` which generate the symbolic expressions for
the models used in `Test_Probability_Calcs`.
New fixtures reduce the run time of the
test suite by roughly 7 seconds since
the expressions only have to be
generated once for the entire class.
