### PR TITLE
MAINT, DOCS: Update `requirements.txt`, fix API docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -60,3 +60,10 @@ urllib3==2.2.2
     # via requests
 zipp==3.19.2
     # via importlib-metadata
+# add kda dependencies so
+# API docs can build properly
+numpy
+sympy
+networkx
+scipy
+matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+sympy
+networkx
+scipy
+matplotlib


### PR DESCRIPTION
## Changes

* Update `docs/requirements.txt` to include main `kda` dependencies so the API docs
can build appropriately on RTD

* Add basic `requirements.txt` to root with `kda` dependencies

* Fixes #95