### PR TITLE
MAINT: Remove unnecessary `graph_utils.py` functions

### DIFF
--- a/docs/autosummary/kda.graph_utils.rst
+++ b/docs/autosummary/kda.graph_utils.rst
@@ -13,8 +13,6 @@
 
    .. autosummary::
    
-      add_graph_attribute
-      add_node_attribute
       find_all_unique_cycles
       generate_K_string_matrix
       generate_edges

--- a/kda/graph_utils.py
+++ b/kda/graph_utils.py
@@ -14,8 +14,6 @@ Functions
 .. autofunction:: find_all_unique_cycles
 .. autofunction:: generate_K_string_matrix
 .. autofunction:: retrieve_rate_matrix
-.. autofunction:: add_node_attribute
-.. autofunction:: add_graph_attribute
 .. autofunction:: get_ccw_cycle
 
 """
@@ -119,41 +117,6 @@ def retrieve_rate_matrix(G, key="val"):
         # use edge indices and edge values to construct rate matrix
         rate_matrix[i, j] = data[key]
     return rate_matrix
-
-
-def add_node_attribute(G, data, label):
-    """
-    Sequentially add attributes to nodes from array of values, i.e. state
-    probabilities.
-
-    Parameters
-    ----------
-    G : NetworkX MultiDiGraph
-        Input diagram
-    data : array like
-        Array or list of length 'n', where 'n' is the number of nodes in the
-        diagram G. Elements must be in order, i.e. [x1, x2, x3, ..., xn]
-    label : str
-        Name of new attribute to be assigned to nodes.
-    """
-    for i in range(G.number_of_nodes()):
-        G.nodes[i][label] = data[i]
-
-
-def add_graph_attribute(G, data, label):
-    """
-    Add attribute to graph G.
-
-    Parameters
-    ----------
-    G : NetworkX MultiDiGraph
-        Input diagram
-    data : anything
-        Data to be assigned as an attribute to G.
-    label : str
-        Name of new attribute to be assigned to nodes.
-    """
-    G.graph[label] = data
 
 
 def find_all_unique_cycles(G):

--- a/kda/tests/test_kda.py
+++ b/kda/tests/test_kda.py
@@ -1051,36 +1051,6 @@ def test_retrieve_rate_matrix():
     assert_array_equal(K, K_new)
 
 
-def test_add_attributes():
-    K = np.array(
-        [
-            [0, 1, 2, 3, 4],
-            [5, 0, 6, 7, 8],
-            [9, 10, 0, 11, 12],
-            [13, 14, 15, 0, 16],
-            [17, 18, 19, 20, 0],
-        ]
-    )
-    # initialize graph object
-    G = nx.MultiDiGraph()
-    # use KDA utility to generate the edges from K
-    graph_utils.generate_edges(G, K)
-
-    # calculate the state probabilities using KDA
-    kda_probs = calculations.calc_state_probs(G, key="val", output_strings=False)
-
-    node_data = kda_probs
-    node_label = "probability"
-    graph_utils.add_node_attribute(G, data=node_data, label=node_label)
-    for i in range(G.number_of_nodes()):
-        assert G.nodes[i][node_label] == kda_probs[i]
-
-    graph_data = K
-    graph_label = "Graph rate matrix"
-    graph_utils.add_graph_attribute(G, data=graph_data, label=graph_label)
-    assert np.all(G.graph[graph_label] == K)
-
-
 def test_generate_edges_errors():
     k_vals = np.array([[0, 1, 2], [5, 0, 6], [9, 10, 0],])
     k_names = np.array(


### PR DESCRIPTION
* Removes `add_node_attribute` and `add_graph_attribute` from `graph_utils.py`

* Removes the associated test, `test_add_attributes`, from `test_kda.py`