### PR TITLE
MAINT: Move fixtures from `test_plotting.py`

### DIFF
--- a/kda/tests/conftest.py
+++ b/kda/tests/conftest.py
@@ -9,10 +9,10 @@ import pytest
 import numpy as np
 import networkx as nx
 
-from kda import graph_utils, calculations
+from kda import graph_utils, calculations, diagrams, ode
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def state_probs_3_state():
 	def _state_probs(k12, k21, k23, k32, k13, k31):
 	    P1 = k23 * k31 + k32 * k21 + k31 * k21
@@ -23,7 +23,7 @@ def state_probs_3_state():
 	return _state_probs
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def symbolic_state_probs_3_state():
 	K = np.array([[0, 1, 1], [1, 0, 1], [1, 1, 0]])
 	G = nx.MultiDiGraph()
@@ -32,7 +32,7 @@ def symbolic_state_probs_3_state():
 	return sympy_funcs
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def state_probs_4_state():
 	def _state_probs(k12, k21, k23, k32, k34, k43, k41, k14):
 	    P1 = k43 * k32 * k21 + k23 * k34 * k41 + k21 * k34 * k41 + k41 * k32 * k21
@@ -44,7 +44,7 @@ def state_probs_4_state():
 	return _state_probs
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def symbolic_state_probs_4_state():
 	K = np.array([
 		[0, 1, 0, 1],
@@ -58,7 +58,7 @@ def symbolic_state_probs_4_state():
 	return sympy_funcs
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def state_probs_4wl():
 	def _state_probs(k12, k21, k23, k32, k34, k43, k41, k14, k24, k42):
 		P1 = (
@@ -106,7 +106,7 @@ def state_probs_4wl():
 	return _state_probs
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def symbolic_state_probs_4wl():
 	K = np.array([
 		[0, 1, 0, 1],
@@ -120,7 +120,7 @@ def symbolic_state_probs_4wl():
 	return sympy_funcs
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def state_probs_5wl():
 	def _state_probs(k12, k21, k23, k32, k13, k31, k24, k42, k35, k53, k45, k54):
 		P1 = (
@@ -193,7 +193,7 @@ def state_probs_5wl():
 	return _state_probs
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def symbolic_state_probs_5wl():
 	K = np.array([
 		[0, 1, 1, 0, 0],
@@ -208,7 +208,7 @@ def symbolic_state_probs_5wl():
 	return sympy_funcs
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def state_probs_6_state():
 	def _state_probs(k12, k21, k23, k32, k34, k43, k45, k54, k56, k65, k61, k16):
 		P1 = (
@@ -264,7 +264,7 @@ def state_probs_6_state():
 	return _state_probs
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def symbolic_state_probs_6_state():
 	K = np.array([
 		[0, 1, 0, 0, 0, 1],
@@ -278,3 +278,45 @@ def symbolic_state_probs_6_state():
 	graph_utils.generate_edges(G, K)
 	sympy_funcs = calculations.calc_state_probs(G, key="name", output_strings=True)
 	return sympy_funcs
+
+
+@pytest.fixture(scope="module")
+def G4wl():
+    k4wl = np.array([[0, 1, 0, 1], [1, 0, 1, 1], [0, 1, 0, 1], [1, 1, 1, 0]])
+    G4wl = nx.MultiDiGraph()
+    graph_utils.generate_edges(G4wl, k4wl)
+    return G4wl
+
+
+@pytest.fixture(scope="module")
+def flux_diagrams_4wl(G4wl):
+    cycles = graph_utils.find_all_unique_cycles(G4wl)
+
+    flux_diagrams = []
+    for cycle in cycles:
+        if not cycle is None:
+            flux_diagrams = diagrams.generate_flux_diagrams(G4wl, cycle)
+            if not flux_diagrams is None:
+                flux_diagrams.extend(flux_diagrams)
+    return flux_diagrams
+
+
+@pytest.fixture(scope="module")
+def pos_4wl():
+    pos = {
+        0: [1, 1],
+        1: [-1, 1],
+        2: [-1, -1],
+        3: [1, -1],
+    }
+    return pos
+
+
+@pytest.fixture(scope="module")
+def results_4wl():
+    k4wl = np.array([[0, 1, 0, 1], [1, 0, 1, 1], [0, 1, 0, 1], [1, 1, 1, 0]])
+    p4wl = np.array([1, 0, 0, 0])
+    results4wl = ode.ode_solver(
+        p4wl, k4wl, t_max=1e2, tol=1e-12, atol=1e-16, rtol=1e-13
+    )
+    return results4wl

--- a/kda/tests/test_kda.py
+++ b/kda/tests/test_kda.py
@@ -1,8 +1,9 @@
 # Nikolaus Awtrey
 # Beckstein Lab
+# Department of Physics
 # Arizona State University
 #
-# Kinetic Diagram Analysis Testing
+# Kinetic Diagram Analysis Tests
 
 import pytest
 import numpy as np

--- a/kda/tests/test_plotting.py
+++ b/kda/tests/test_plotting.py
@@ -1,8 +1,9 @@
 # Nikolaus Awtrey
 # Beckstein Lab
+# Department of Physics
 # Arizona State University
 #
-# Kinetic Diagram Analyzer Testing
+# Kinetic Diagram Analysis Plotting Tests
 
 import os
 import pytest
@@ -12,51 +13,7 @@ import matplotlib.pyplot as plt
 
 from numpy.testing import assert_equal
 
-from kda import plotting, graph_utils, diagrams, ode
-
-
-@pytest.fixture(scope="module")
-def G4wl():
-    k4wl = np.array([[0, 1, 0, 1], [1, 0, 1, 1], [0, 1, 0, 1], [1, 1, 1, 0]])
-    G4wl = nx.MultiDiGraph()
-    graph_utils.generate_edges(G4wl, k4wl)
-    return G4wl
-
-
-@pytest.fixture(scope="function")
-def flux_diagrams_4wl(G4wl):
-    cycles = graph_utils.find_all_unique_cycles(G4wl)
-
-    flux_diagrams = []
-    for cycle in cycles:
-        if not cycle is None:
-            flux_diagrams = diagrams.generate_flux_diagrams(G4wl, cycle)
-            if not flux_diagrams is None:
-                flux_diagrams.extend(flux_diagrams)
-    return flux_diagrams
-
-
-@pytest.fixture(scope="module")
-def pos_4wl():
-    pos = {
-        0: [1, 1],
-        1: [-1, 1],
-        2: [-1, -1],
-        3: [1, -1],
-    }
-    return pos
-
-
-@pytest.fixture(scope="module")
-def results_4wl():
-    k4wl = np.array([[0, 1, 0, 1], [1, 0, 1, 1], [0, 1, 0, 1], [1, 1, 1, 0]])
-    G4wl = nx.MultiDiGraph()
-    graph_utils.generate_edges(G4wl, k4wl)
-    p4wl = np.array([1, 0, 0, 0])
-    results4wl = ode.ode_solver(
-        p4wl, k4wl, t_max=1e2, tol=1e-12, atol=1e-16, rtol=1e-13
-    )
-    return results4wl
+from kda import plotting, graph_utils, diagrams
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Changes

* Move fixtures from `test_plotting.py` to `conftest.py` to make them more broadly
available to other tests.

* Change scope of fixtures in `conftest.py` from "class" to "module"
since they can all be used across an
entire module

* Fix comments in `test_kda.py` and `test_plotting.py`

* Remove unnecessary code from testing fixture `results_4wl`
