### PR TITLE
ENH: Improve directional diagram algo

### DIFF
--- a/kda/diagrams.py
+++ b/kda/diagrams.py
@@ -383,7 +383,7 @@ def generate_directional_diagrams(G, return_edges=False):
 
     Returns
     -------
-    directional_diagrams : ndarray or ndarray of ``NetworkX.MultiDiGraph``
+    directional_diagrams : ndarray or ndarray of ``NetworkX.DiGraph``
         Array of all directional diagram edges made from 3-tuples
         (``return_edges=True``) or array of all directional
         diagrams (``return_edges=False``) for ``G``.
@@ -409,19 +409,20 @@ def generate_directional_diagrams(G, return_edges=False):
             # a directed spanning tree where the edges are directed
             # from the target node to the leaf nodes
             G_dfs = nx.dfs_tree(G_partial, source=target)
-            # collect the edges from the directed spanning tree
-            # and reverse the direction of the edges to get the correct
-            # edges for a directional diagram
-            dir_edges = np.fliplr(np.asarray(G_dfs.edges(), dtype=np.int32))
-            # add in the zero column for now
-            # TODO: change downstream functions so we
-            # don't have to keep these unnecessary zeros
-            dir_edges = np.column_stack((dir_edges, np.zeros(dir_edges.shape[0])))
             if return_edges:
+                # collect the edges from the directed spanning tree
+                # and reverse the direction of the edges to get the correct
+                # edges for a directional diagram
+                dir_edges = np.fliplr(np.asarray(G_dfs.edges(), dtype=np.int32))
+                # add in the zero column for now
+                # TODO: change downstream functions so we
+                # don't have to keep these unnecessary zeros
+                dir_edges = np.column_stack((dir_edges, np.zeros(dir_edges.shape[0])))
                 directional_diagrams[j + i*n_partials] = dir_edges
             else:
-                G_directional = nx.MultiDiGraph()
-                G_directional.add_edges_from(dir_edges)
+                # make a copy of the `nx.DiGraph` with reversed
+                # edges to get the directional diagram
+                G_directional = G_dfs.reverse(copy=True)
                 # set "is_target" to False for all nodes
                 nx.set_node_attributes(G_directional, False, "is_target")
                 # set target node to True

--- a/kda/diagrams.py
+++ b/kda/diagrams.py
@@ -369,7 +369,8 @@ def generate_partial_diagrams(G, return_edges=False):
 
 def generate_directional_diagrams(G, return_edges=False):
     """
-    Generates all directional diagrams for a kinetic diagram.
+    Generates all directional diagrams for a kinetic diagram
+    using depth-first-search algorithm.
 
     Parameters
     ----------
@@ -382,11 +383,10 @@ def generate_directional_diagrams(G, return_edges=False):
 
     Returns
     -------
-    directional_diagrams : ndarray of ``NetworkX.MultiDiGraph``
-        Array of all directional diagrams for ``G``.
-    directional_diagram_edges : ndarray
-        Array of edges (made from 2-tuples) for valid directional
-        diagrams.
+    directional_diagrams : ndarray or ndarray of ``NetworkX.MultiDiGraph``
+        Array of all directional diagram edges made from 3-tuples
+        (``return_edges=True``) or array of all directional
+        diagrams (``return_edges=False``) for ``G``.
     """
     partial_diagrams = generate_partial_diagrams(G, return_edges=False)
 

--- a/kda/diagrams.py
+++ b/kda/diagrams.py
@@ -132,68 +132,6 @@ def _get_flux_path_edges(target, unique_edges):
     return list(set(path_edges))
 
 
-def _collect_sources(G):
-    """
-    Finds all nodes in a diagram with a single neighbor. Used
-    to find the leaf nodes in a spanning tree (partial diagram).
-
-    Parameters
-    ----------
-    G : ``NetworkX.Graph``
-        A partial diagram
-
-    Returns
-    -------
-    sources: list of int
-        List of nodes with a single neighbor.
-
-    """
-    sources = []
-    for n in G.nodes:
-        if len(list(G.neighbors(n))) == 1:
-            # sources should only have a single neighbor, but
-            # this may not be true for more advanced cases
-            sources.append(n)
-    return sources
-
-
-def _get_directional_path_edges(G, target):
-    """
-    Collects edges for all paths leading to a
-    target state for an input partial diagram.
-
-    Parameters
-    ----------
-    G : ``NetworkX.MultiDiGraph``
-        A kinetic diagram
-    target : int
-        Target state.
-
-    Returns
-    -------
-    path_edges : list
-        List of edge tuples (e.g. ``[(0, 1, 0), (1, 2, 0), ...]``).
-
-    """
-    sources = _collect_sources(G)
-    # purge target from source list
-    sources = [n for n in sources if n != target]
-    # NetworkX function allows for multiple target states but not
-    # multiple sources. So instead of iterating over each available
-    # source, we can instead flip the direction of the paths to avoid
-    # a for loop
-    paths = list(nx.all_simple_edge_paths(G, source=target, target=sources))
-    # flatten the path edges and remove redundant edge tuples
-    path_edges = np.unique([edge for path in paths for edge in path], axis=0)
-    # flip edge tuples to account for our targets and sources being flipped
-    path_edges = np.fliplr(path_edges)
-    # add in the zero column for now
-    # TODO: change downstream functions so we
-    # don't have to keep these unnecessary zeros
-    path_edges = np.column_stack((path_edges, np.zeros(path_edges.shape[0])))
-    return path_edges
-
-
 def _construct_cycle_edges(cycle):
     """
     Constucts edge tuples in a cycle using the node indices in the cycle. It
@@ -461,22 +399,35 @@ def generate_directional_diagrams(G, return_edges=False):
     else:
         directional_diagrams = np.empty((n_dir_diags,), dtype=object)
 
+    # get the set of target nodes in ascending order
+    # so all directional diagrams for each state are
+    # generated in order
     targets = np.sort(list(G.nodes))
     for i, target in enumerate(targets):
-        for j, partial_diagram in enumerate(partial_diagrams):
-            # get directional edges from partial diagram edges
-            dir_edges = _get_directional_path_edges(partial_diagram, target)
+        for j, G_partial in enumerate(partial_diagrams):
+            # apply depth-first-search to partial diagram to create
+            # a directed spanning tree where the edges are directed
+            # from the target node to the leaf nodes
+            G_dfs = nx.dfs_tree(G_partial, source=target)
+            # collect the edges from the directed spanning tree
+            # and reverse the direction of the edges to get the correct
+            # edges for a directional diagram
+            dir_edges = np.fliplr(np.asarray(G_dfs.edges(), dtype=np.int32))
+            # add in the zero column for now
+            # TODO: change downstream functions so we
+            # don't have to keep these unnecessary zeros
+            dir_edges = np.column_stack((dir_edges, np.zeros(dir_edges.shape[0])))
             if return_edges:
                 directional_diagrams[j + i*n_partials] = dir_edges
             else:
-                directional_diagram = nx.MultiDiGraph()
-                directional_diagram.add_edges_from(dir_edges)
+                G_directional = nx.MultiDiGraph()
+                G_directional.add_edges_from(dir_edges)
                 # set "is_target" to False for all nodes
-                nx.set_node_attributes(directional_diagram, False, "is_target")
+                nx.set_node_attributes(G_directional, False, "is_target")
                 # set target node to True
-                directional_diagram.nodes[target]["is_target"] = True
+                G_directional.nodes[target]["is_target"] = True
                 # add to array of directional diagrams
-                directional_diagrams[j + i*n_partials] = directional_diagram
+                directional_diagrams[j + i*n_partials] = G_directional
 
     return directional_diagrams
 


### PR DESCRIPTION
## Description
This branch changes the way we generate directional diagrams from partial diagrams. Since the paths for the directional diagrams are known ahead of time, we can use a depth-first-search algorithm to find the directed versions of the paths. `NetworkX.dfs_tree` returns the correct diagrams but with the edges reversed (our previous algorithm also did this) so we simply reverse the edges like before and voila! The new algorithm is significantly more efficient for larger graphs (see results below) and still noticeably faster for small graphs. 

## Changes

* Changes directional diagram algorithm 
to use depth-first-search (i.e. `nx.dfs_tree`)
to create the directional diagrams. Also
uses the `nx.DiGraph.reverse` method to build
the directional diagram with reversed edges
and changes directional diagram return type
for `return_edges=False` to a `nx.DiGraph`.

* Removes private functions 
`diagrams._collect_sources` and
`diagrams.get_directional_path_edges`

* Move array-based edge flipping code into
the `return_edges=True` code path

* Addresses the directional diagram 
algo improvement portion of #22

# Performance changes

On this branch we see a significant increase in performance for many of the benchmarks. Running `$ asv continuous master improve_dir_edge_generation` showed improvements even for some of the functions from `calculations.py` because they rely on generating the diagrams to create the expressions.
```
| Change   | Before [9493049b] <master>   | After [0ae72b58] <improve_dir_edge_generation>   |   Ratio | Benchmark (Parameter)
|----------|------------------------------|--------------------------------------------------|---------|--------------------------------------------------------|
| -        | 3.17±0.3ms                   | 2.22±0.1ms                                       |    0.7  | time_calc_state_probs('3-state', True)
| -        | 83.1±10μs                    | 54.3±2μs                                         |    0.65 | time_calc_sigma('3-state', False)
| -        | 14.4±0.9ms                   | 8.73±0.1ms                                       |    0.61 | time_calc_state_probs('Hill-5-state', True)
| -        | 1.57±0.03ms                  | 807±20μs                                         |    0.51 | time_generate_directional_diagrams('3-state', False)
| -        | 687±40ms                     | 352±2ms                                          |    0.51 | time_generate_directional_diagrams('EmrE-8-state', False)
| -        | 1.47±0.07ms                  | 715±20μs                                         |    0.49 | time_calc_state_probs('3-state', False)
| -        | 9.88±0.2ms                   | 4.89±0.3ms                                       |    0.49 | time_generate_directional_diagrams('Hill-5-state', False)
| -        | 102±0.8ms                    | 49.8±1ms                                         |    0.49 | time_generate_directional_diagrams('Hill-8-state', False)
| -        | 1.29±0.02ms                  | 584±30μs                                         |    0.45 | time_generate_directional_diagrams('3-state', True)
| -        | 495±6ms                      | 199±10ms                                         |    0.4  | time_calc_state_probs('EmrE-8-state', False)
| -        | 8.10±0.3ms                   | 3.23±0.02ms                                      |    0.4  | time_calc_state_probs('Hill-5-state', False)
| -        | 74.6±2ms                     | 28.4±1ms                                         |    0.38 | time_calc_state_probs('Hill-8-state', False)
| -        | 471±4ms                      | 165±3ms                                          |    0.35 | time_generate_directional_diagrams('EmrE-8-state', True)
| -        | 7.38±0.09ms                  | 2.53±0.03ms                                      |    0.34 | time_generate_directional_diagrams('Hill-5-state', True)
| -        | 80.8±20ms                    | 23.2±0.3ms                                       |    0.29 | time_generate_directional_diagrams('Hill-8-state', True)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```