### PR TITLE
BENCH: Add cycle flux benchmark

### DIFF
--- a/benchmarks/benchmarks/bench_calculations.py
+++ b/benchmarks/benchmarks/bench_calculations.py
@@ -4,6 +4,7 @@
 import numpy as np
 import networkx as nx
 
+import kda
 from kda import graph_utils, calculations, diagrams
 
 
@@ -150,3 +151,60 @@ class Sigma:
             key=self.key,
             output_strings=output_strings,
         )
+
+
+class CycleFlux:
+    """
+    A benchmark to test the time and space complexity of the
+    `calculations.calc_net_cycle_flux()` function.
+    """
+    param_names = ["graph", "output_strings"]
+    params = [
+        [
+            "3-state",
+            "Hill-5-state",
+            "Hill-8-state",
+        ],
+        [
+            True,
+            False,
+        ]
+    ]
+
+    def setup(self, graph, output_strings):
+        if output_strings:
+            key = "name"
+        else:
+            key = "val"
+        self.key = key
+        G = build_graph(graph=graph)
+        model = kda.KineticModel(G=G)
+        model.build_cycles()
+        self.G = model.G
+        self.cycles = model.cycles
+        self.dir_edges = diagrams.generate_directional_diagrams(
+            G=self.G, return_edges=True)
+
+    def time_calc_net_cycle_flux(self, graph, output_strings):
+        # benchmark cycle flux calculation algorithm
+        # for various models we commonly use for testing
+        for cycle in self.cycles:
+            calculations.calc_net_cycle_flux(
+                G=self.G,
+                cycle=cycle,
+                order=cycle[:2],
+                key=self.key,
+                output_strings=output_strings,
+                dir_edges=self.dir_edges,
+            )
+
+    def peakmem_calc_net_cycle_flux(self, graph, output_strings):
+        for cycle in self.cycles:
+            calculations.calc_net_cycle_flux(
+                G=self.G,
+                cycle=cycle,
+                order=cycle[:2],
+                key=self.key,
+                output_strings=output_strings,
+                dir_edges=self.dir_edges,
+            )


### PR DESCRIPTION
## Description
I'm adding a benchmark for `calc_net_cycle_flux` since future changes will likely affect its performance, and it would be good to know how well (or poorly) it is performing beforehand. 

Here are the results of the new benchmarks from a local run:
```
$ asv run -b CycleFlux*
Couldn't load asv.plugins._mamba_helpers because
No module named 'libmambapy'
▒ Creating environments
▒ Discovering benchmarks
▒▒ Uninstalling from conda-py3.9-pip+networkx-pip+numpy-pip+pytest-pip+sympy
▒▒ Building 5349eb49 <add_cycle_flux_bench> for conda-py3.9-pip+networkx-pip+numpy-pip+pytest-pip+sympy
▒▒ Installing 5349eb49 <add_cycle_flux_bench> into conda-py3.9-pip+networkx-pip+numpy-pip+pytest-pip+sympy
▒ Running 2 total benchmarks (1 commits * 1 environments * 2 benchmarks)
[ 0.00%] ▒ For kda commit 5349eb49 <add_cycle_flux_bench>:
[ 0.00%] ▒▒ Benchmarking conda-py3.9-pip+networkx-pip+numpy-pip+pytest-pip+sympy
[50.00%] ▒▒▒ Running (bench_calculations.CycleFlux.time_calc_net_cycle_flux--).
[75.00%] ▒▒▒ ...ations.CycleFlux.peakmem_calc_net_cycle_flux                ok
[75.00%] ▒▒▒ ============== ======= =======
             --              output_strings
             -------------- ---------------
                 graph        True   False
             ============== ======= =======
                3-state      73.3M   72.2M
              Hill-5-state   74.9M   72.6M
              Hill-8-state   83.2M   72.7M
             ============== ======= =======

[100.00%] ▒▒▒ ...culations.CycleFlux.time_calc_net_cycle_flux                ok
[100.00%] ▒▒▒ ============== ============= =============
              --                    output_strings
              -------------- ---------------------------
                  graph           True         False
              ============== ============= =============
                 3-state      1.80~0.01ms     756~30us
               Hill-5-state    22.6▒0.2ms   7.52▒0.05ms
               Hill-8-state    8.07▒0.02s    70.7▒0.8ms
              ============== ============= =============
```

I'll just note that I chose _not_ to add the `EmrE-8-state` model here because it 1.) results in a `RecursionError` and 2.) takes absolutely forever. The Hill 8-state model is already plenty complex to capture the [lack of] performance here, so I didn't think it was worth the hassle. 

## Changes

* Adds new benchmarks for the `calculations.calc_net_cycle_flux` function.
Benchmark calculates the net cycle flux for
all cycles in each diagram so it will scale
not only with performance, but also with
the number of cycles.