### PR TITLE
CI: Add `asv check` to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,4 +48,4 @@ jobs:
       - name: asv check
         run: |
           python -m pip install -r ./requirements_dev.txt
-          python -m asv check -E existing
+          python -m asv check -E existing --config ./benchmarks/asv.conf.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,8 @@ jobs:
           file: coverage.xml
           fail_ci_if_error: False
           verbose: True
+
+      - name: asv check
+        run: |
+          python -m pip install -r ./requirements_dev.txt
+          python -m asv check -E existing

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Kinetic Diagram Analysis
 [![CI](https://github.com/Becksteinlab/kda/actions/workflows/test.yml/badge.svg)](https://github.com/Becksteinlab/kda/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/Becksteinlab/kda/branch/master/graph/badge.svg)](https://codecov.io/gh/Becksteinlab/kda/branch/master)
 [![Documentation Status](https://readthedocs.org/projects/kda/badge/?version=latest)](https://kda.readthedocs.io/en/latest/?badge=latest)
+[![asv](http://img.shields.io/badge/benchmarked%20by-asv-blue.svg?style=flat)](https://github.com/Becksteinlab/kda/actions/workflows/test.yml)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5826394.svg)](https://doi.org/10.5281/zenodo.5826394)
 
 Python package used for the analysis of biochemical kinetic diagrams using the diagrammatic approach developed by [T.L. Hill](https://link.springer.com/book/10.1007/978-1-4612-3558-3).


### PR DESCRIPTION
## Changes

* Adds a check for `asv` benchmarks to CI just to make sure our benchmarks
are not breaking between commits.

* Related to #108
