### PR TITLE
ENH: Enable one-way cycle flux calculations

### DIFF
--- a/kda/calculations.py
+++ b/kda/calculations.py
@@ -306,7 +306,6 @@ def calc_pi_difference(G, cycle, order, key="name",
         ``NetworkX`` edge key is ``"weight"``, however the ``kda`` edge keys
         are ``"name"`` (for rate constant names, e.g. ``"k12"``) and ``"val"``
         (for the rate constant values, e.g. ``100``). Default is ``"name"``.
-        Default is ``"name"``.
     output_strings : bool (optional)
         Used to denote whether values or strings will be combined. Default
         is ``False``, which tells the function to calculate the difference
@@ -314,8 +313,8 @@ def calc_pi_difference(G, cycle, order, key="name",
         will return strings of variable names to join into the analytic
         function.
     net : bool (optional)
-        Used to determine whether to return the _forward_ cycle product
-        (i.e., ``net=False``) or the _difference_ of the forward and reverse
+        Used to determine whether to return the forward cycle product
+        (i.e., ``net=False``) or the difference of the forward and reverse
         cycle products (i.e., ``net=True``). Default is ``True``.
 
     Returns
@@ -595,7 +594,6 @@ def calc_cycle_flux(G, cycle, order, key="name",
         ``NetworkX`` edge key is ``"weight"``, however the ``kda`` edge keys
         are ``"name"`` (for rate constant names, e.g. ``"k12"``) and ``"val"``
         (for the rate constant values, e.g. ``100``). Default is ``"name"``.
-        Default is ``"name"``.
     output_strings : bool (optional)
         Used to denote whether values or strings will be combined. Default
         is ``False``, which tells the function to calculate the cycle flux
@@ -610,8 +608,8 @@ def calc_cycle_flux(G, cycle, order, key="name",
         Created using :meth:`~kda.diagrams.generate_directional_diagrams`
         with ``return_edges=True``.
     net : bool (optional)
-        Used to determine whether to return the _one-way_ or _net_ cycle flux.
-        Default is ``True`` (i.e., to generate the _net_ cycle flux).
+        Used to determine whether to return the one-way or net cycle flux.
+        Default is ``True`` (i.e., to generate the net cycle flux).
 
     Returns
     -------

--- a/kda/tests/test_kda.py
+++ b/kda/tests/test_kda.py
@@ -467,7 +467,7 @@ class Test_Flux_Diagrams:
         cycle = [0, 1, 3]
         order = [0, 1]
         # calculate the net cycle flux
-        net_cycle_flux = calculations.calc_net_cycle_flux(
+        net_cycle_flux = calculations.calc_cycle_flux(
             G,
             dir_edges=dir_edges,
             cycle=cycle,
@@ -476,7 +476,7 @@ class Test_Flux_Diagrams:
             output_strings=False,
         )
         # generate the net cycle flux function
-        net_cycle_flux_sympy_func = calculations.calc_net_cycle_flux(
+        net_cycle_flux_sympy_func = calculations.calc_cycle_flux(
             G,
             dir_edges=dir_edges,
             cycle=cycle,
@@ -522,11 +522,11 @@ class Test_Flux_Diagrams:
         cycle = [0, 2, 1]
         order = [0, 1]
         # calculate the net cycle flux
-        net_cycle_flux = calculations.calc_net_cycle_flux(
+        net_cycle_flux = calculations.calc_cycle_flux(
             G, cycle=cycle, order=order, key="val", output_strings=False
         )
         # generate the sympy net cycle flux function
-        sympy_net_cycle_flux_func = calculations.calc_net_cycle_flux(
+        sympy_net_cycle_flux_func = calculations.calc_cycle_flux(
             G, cycle=cycle, order=order, key="name", output_strings=True
         )
         # make sure the sympy function agrees with the known solution


### PR DESCRIPTION
## Description

* Changes `calc_net_cycle_flux` to `calc_cycle_flux`, and adds parameter `net` to toggle between one-way and net cycle fluxes

* Updates `calc_pi_difference` to allow for retrieving the forward cycle rate product by adding the same `net` parameter (`net=True` returns the cycle product difference)

* Updates call signatures throughout `calculations.py` and `test_kda.py`

* Related to issue #57

## Status
- [ ] Ready to go