### PR TITLE
DOC: Minor updates to docstrings

### DIFF
--- a/kda/calculations.py
+++ b/kda/calculations.py
@@ -109,23 +109,23 @@ def calc_sigma(G, dir_edges=None, key="name", output_strings=True, **kwargs):
     ----------
     G : ``NetworkX.MultiDiGraph``
         A kinetic diagram
-    dir_edges : ndarray (optional)
+    dir_edges : ndarray, optional
         Array of all directional diagram edges (made from 2-tuples)
         for the input diagram ``G``. Created using
-        :meth:`~kda.diagrams.generate_directional_diagrams`
+        :func:`~kda.diagrams.generate_directional_diagrams`
         with ``return_edges=True``.
-    key : str (optional)
+    key : str, optional
         Attribute key used to retrieve edge data from ``G.edges``. The default
         ``NetworkX`` edge key is ``"weight"``, however the ``kda`` edge keys
         are ``"name"`` (for rate constant names, e.g. ``"k12"``) and ``"val"``
         (for the rate constant values, e.g. ``100``). Default is ``"name"``.
-    output_strings : bool (optional)
+    output_strings : bool, optional
         Used to denote whether values or strings will be combined. Default
         is ``False``, which tells the function to calculate the normalization
         factor using numbers. If ``True``, this will assume the input
         ``'key'`` will return strings of variable names to join into the
         analytic cycle flux function.
-    kwargs : dict (optional)
+    kwargs : dict, optional
         Additional keyword arguments. Note that the alias
         ``dirpar_edges`` is deprecated; please use ``dir_edges``.
 
@@ -228,13 +228,13 @@ def calc_sigma_K(G, cycle, flux_diags, key="name", output_strings=True):
         indices does not matter but should not contain all nodes.
     flux_diags : list
         List of relevant directional flux diagrams for input cycle.
-    key : str
+    key : str, optional
         Attribute key used to retrieve edge data from ``G.edges``. The default
         ``NetworkX`` edge key is ``"weight"``, however the ``kda`` edge keys
         are ``"name"`` (for rate constant names, e.g. ``"k12"``) and ``"val"``
         (for the rate constant values, e.g. ``100``). Default is ``"name"``.
         Default is ``"name"``.
-    output_strings : bool (optional)
+    output_strings : bool, optional
         Used to denote whether values or strings will be combined. Default
         is ``False``, which tells the function to calculate the sum of all
         directional flux diagrams using numbers. If ``True``, this will assume
@@ -325,18 +325,18 @@ def calc_pi_difference(G, cycle, order, key="name",
         List of integers of length 2 (e.g. ``[0, 1]``), where the integers are
         nodes in ``cycle``. The pair of nodes should be ordered such that
         a counter-clockwise path is followed.
-    key : str
+    key : str, optional
         Attribute key used to retrieve edge data from ``G.edges``. The default
         ``NetworkX`` edge key is ``"weight"``, however the ``kda`` edge keys
         are ``"name"`` (for rate constant names, e.g. ``"k12"``) and ``"val"``
         (for the rate constant values, e.g. ``100``). Default is ``"name"``.
-    output_strings : bool (optional)
+    output_strings : bool, optional
         Used to denote whether values or strings will be combined. Default
         is ``False``, which tells the function to calculate the difference
         using numbers. If ``True``, this will assume the input ``'key'``
         will return strings of variable names to join into the analytic
         function.
-    net : bool (optional)
+    net : bool, optional
         Used to determine whether to return the forward cycle product
         (i.e., ``net=False``) or the difference of the forward and reverse
         cycle products (i.e., ``net=True``). Default is ``True``.
@@ -418,13 +418,13 @@ def calc_thermo_force(G, cycle, order, key="name", output_strings=True):
         List of integers of length 2 (e.g. ``[0, 1]``), where the integers are
         nodes in ``cycle``. The pair of nodes should be ordered such that
         a counter-clockwise path is followed.
-    key : str
+    key : str, optional
         Attribute key used to retrieve edge data from ``G.edges``. The default
         ``NetworkX`` edge key is ``"weight"``, however the ``kda`` edge keys
         are ``"name"`` (for rate constant names, e.g. ``"k12"``) and ``"val"``
         (for the rate constant values, e.g. ``100``). Default is ``"name"``.
         Default is ``"name"``.
-    output_strings : bool (optional)
+    output_strings : bool, optional
         Used to denote whether values or strings will be combined. Default
         is ``False``, which tells the function to calculate the thermodynamic
         force using numbers. If ``True``, this will assume the input
@@ -499,21 +499,21 @@ def calc_state_probs(G, key="name", output_strings=True, dir_edges=None):
     ----------
     G : ``NetworkX.MultiDiGraph``
         A kinetic diagram
-    key : str
+    key : str, optional
         Attribute key used to retrieve edge data from ``G.edges``. The default
         ``NetworkX`` edge key is ``"weight"``, however the ``kda`` edge keys
         are ``"name"`` (for rate constant names, e.g. ``"k12"``) and ``"val"``
         (for the rate constant values, e.g. ``100``). Default is ``"name"``.
-    output_strings : bool (optional)
+    output_strings : bool, optional
         Used to denote whether values or strings will be combined. Default
         is ``False``, which tells the function to calculate the state
         probabilities using numbers. If ``True``, this will assume the input
         ``'key'`` will return strings of variable names to join into the
         analytic state multplicity and normalization function.
-    dir_edges : ndarray (optional)
+    dir_edges : ndarray, optional
         Array of all directional diagram edges (made from 2-tuples)
         for the input diagram ``G``. Created using
-        :meth:`~kda.diagrams.generate_directional_diagrams`
+        :func:`~kda.diagrams.generate_directional_diagrams`
         with ``return_edges=True``.
 
     Returns
@@ -613,25 +613,25 @@ def calc_cycle_flux(G, cycle, order, key="name",
         List of integers of length 2 (e.g. ``[0, 1]``), where the integers are
         nodes in ``cycle``. The pair of nodes should be ordered such that
         a counter-clockwise path is followed.
-    key : str
+    key : str, optional
         Attribute key used to retrieve edge data from ``G.edges``. The default
         ``NetworkX`` edge key is ``"weight"``, however the ``kda`` edge keys
         are ``"name"`` (for rate constant names, e.g. ``"k12"``) and ``"val"``
         (for the rate constant values, e.g. ``100``). Default is ``"name"``.
-    output_strings : bool (optional)
+    output_strings : bool, optional
         Used to denote whether values or strings will be combined. Default
         is ``False``, which tells the function to calculate the cycle flux
         using numbers. If ``True``, this will assume the input ``'key'``
         will return strings of variable names to join into the analytic
         cycle flux function.
-    dir_edges : ndarray (optional)
+    dir_edges : ndarray, optional
         Array of all directional diagram edges (made from 2-tuples)
         for the input diagram ``G``. Given as an option for performance reasons
         (when calculating net cycle fluxes for multiple cycles it is best to
         generate the directional diagram edges up front and provide them).
-        Created using :meth:`~kda.diagrams.generate_directional_diagrams`
+        Created using :func:`~kda.diagrams.generate_directional_diagrams`
         with ``return_edges=True``.
-    net : bool (optional)
+    net : bool, optional
         Used to determine whether to return the one-way or net cycle flux.
         Default is ``True`` (i.e., to generate the net cycle flux).
 
@@ -700,24 +700,24 @@ def calc_net_cycle_flux(G, cycle, order, key="name",
         List of integers of length 2 (e.g. ``[0, 1]``), where the integers are
         nodes in ``cycle``. The pair of nodes should be ordered such that
         a counter-clockwise path is followed.
-    key : str (optional)
+    key : str, optional
         Attribute key used to retrieve edge data from ``G.edges``. The default
         ``NetworkX`` edge key is ``"weight"``, however the ``kda`` edge keys
         are ``"name"`` (for rate constant names, e.g. ``"k12"``) and ``"val"``
         (for the rate constant values, e.g. ``100``). Default is ``"name"``.
         Default is ``"name"``.
-    output_strings : bool (optional)
+    output_strings : bool, optional
         Used to denote whether values or strings will be combined. Default
         is ``False``, which tells the function to calculate the cycle flux
         using numbers. If ``True``, this will assume the input ``'key'``
         will return strings of variable names to join into the analytic
         cycle flux function.
-    dir_edges : ndarray (optional)
+    dir_edges : ndarray, optional
         Array of all directional diagram edges (made from 2-tuples)
         for the input diagram ``G``. Given as an option for performance reasons
         (when calculating net cycle fluxes for multiple cycles it is best to
         generate the directional diagram edges up front and provide them).
-        Created using :meth:`~kda.diagrams.generate_directional_diagrams`
+        Created using :func:`~kda.diagrams.generate_directional_diagrams`
         with ``return_edges=True``.
 
     Returns
@@ -764,7 +764,7 @@ def calc_state_probs_from_diags(
     method developed by King and Altman :footcite:`king_schematic_1956` and
     Hill :footcite:`hill_studies_1966`. If directional diagram edges are already
     generated this offers better performance than
-    :meth:`~kda.calculations.calc_state_probs`.
+    :func:`~kda.calculations.calc_state_probs`.
 
     .. deprecated:: 0.3.0
        ``calc_state_probs_from_diags`` is deprecated and will be removed in
@@ -775,23 +775,23 @@ def calc_state_probs_from_diags(
     ----------
     G : ``NetworkX.MultiDiGraph``
         A kinetic diagram
-    dir_edges : array (optional)
+    dir_edges : array, optional
         Array of all directional diagram edges (made from 2-tuples)
         for the input diagram ``G``.  Created using
-        :meth:`~kda.diagrams.generate_directional_diagrams`
+        :func:`~kda.diagrams.generate_directional_diagrams`
         with ``return_edges=True``.
-    key : str (optional)
+    key : str, optional
         Attribute key used to retrieve edge data from ``G.edges``. The default
         ``NetworkX`` edge key is ``"weight"``, however the ``kda`` edge keys
         are ``"name"`` (for rate constant names, e.g. ``"k12"``) and ``"val"``
         (for the rate constant values, e.g. ``100``). Default is ``"name"``.
-    output_strings : bool (optional)
+    output_strings : bool, optional
         Used to denote whether values or strings will be combined. Default
         is ``False``, which tells the function to calculate the state
         probabilities using numbers. If ``True``, this will assume the input
         ``'key'`` will return strings of variable names to join into the
         analytic state multplicity and normalization functions.
-    kwargs : dict (optional)
+    kwargs : dict, optional
         Additional keyword arguments. Note that the alias
         ``dirpar_edges`` is deprecated; please use ``dir_edges``.
 
@@ -850,7 +850,7 @@ def calc_net_cycle_flux_from_diags(
     """Generates the expression for the net cycle flux for some ``cycle``
     in kinetic diagram ``G``. If directional diagram edges are already
     generated this offers better performance than
-    :meth:`~kda.calculations.calc_cycle_flux`.
+    :func:`~kda.calculations.calc_cycle_flux`.
 
     .. deprecated:: 0.3.0
        ``calc_net_cycle_flux_from_diags`` is deprecated and will be removed
@@ -868,23 +868,23 @@ def calc_net_cycle_flux_from_diags(
         List of integers of length 2 (e.g. ``[0, 1]``), where the integers are
         nodes in ``cycle``. The pair of nodes should be ordered such that
         a counter-clockwise path is followed.
-    dir_edges : ndarray (optional)
+    dir_edges : ndarray, optional
         Array of all directional diagram edges (made from 2-tuples)
         for the input diagram ``G``. Created using
-        :meth:`~kda.diagrams.generate_directional_diagrams`
+        :func:`~kda.diagrams.generate_directional_diagrams`
         with ``return_edges=True``.
-    key : str (optional)
+    key : str, optional
         Attribute key used to retrieve edge data from ``G.edges``. The default
         ``NetworkX`` edge key is ``"weight"``, however the ``kda`` edge keys
         are ``"name"`` (for rate constant names, e.g. ``"k12"``) and ``"val"``
         (for the rate constant values, e.g. ``100``). Default is ``"name"``.
-    output_strings : bool (optional)
+    output_strings : bool, optional
         Used to denote whether values or strings will be combined. Default
         is ``False``, which tells the function to calculate the cycle flux
         using numbers. If ``True``, this will assume the input ``'key'``
         will return strings of variable names to join into the analytic
         cycle flux function.
-    kwargs : dict (optional)
+    kwargs : dict, optional
         Additional keyword arguments. Note that the alias
         ``dirpar_edges`` is deprecated; please use ``dir_edges``.
 

--- a/kda/core.py
+++ b/kda/core.py
@@ -63,13 +63,13 @@ class KineticModel(object):
 		"""
 		Parameters
 		==========
-		K : ndarray (optional)
+		K : ndarray, optional
 			``NxN`` array where ``N`` is the number of nodes in the
 			diagram ``G``. Adjacency matrix for ``G`` where each element
 			``kij`` is the edge weight (i.e. transition rate constant).
 			For example, for a 2-state model with ``k12=3`` and ``k21=4``,
 			``K=[[0, 3], [4, 0]]``. Default is ``None``.
-		G : ``NetworkX.MultiDiGraph`` (optional)
+		G : ``NetworkX.MultiDiGraph``, optional
 			A kinetic diagram. Default is ``None``.
 
 		Raises
@@ -100,14 +100,14 @@ class KineticModel(object):
 
 	def build_cycles(self):
 		"""Builds all cycles from the kinetic diagram using
-		:meth:`~kda.graph_utils.find_all_unique_cycles()`.
+		:func:`~kda.graph_utils.find_all_unique_cycles()`.
 		"""
 		self.cycles = graph_utils.find_all_unique_cycles(self.G)
 
 
 	def build_partial_diagrams(self):
 		"""Builds the partial diagrams for the kinetic diagram using
-		:meth:`~kda.diagrams.generate_partial_diagrams()`.
+		:func:`~kda.diagrams.generate_partial_diagrams()`.
 		"""
 		self.partial_diagrams = diagrams.generate_partial_diagrams(
 			self.G, return_edges=False)
@@ -115,7 +115,7 @@ class KineticModel(object):
 
 	def build_directional_diagrams(self):
 		"""Builds the directional diagrams for the kinetic diagram using
-		:meth:`~kda.diagrams.generate_directional_diagrams()`.
+		:func:`~kda.diagrams.generate_directional_diagrams()`.
 		"""
 		self.directional_diagrams = diagrams.generate_directional_diagrams(
 			self.G, return_edges=False)
@@ -123,7 +123,7 @@ class KineticModel(object):
 
 	def build_flux_diagrams(self):
 		"""Builds the flux diagrams for the kinetic diagram using
-		:meth:`~kda.diagrams.generate_all_flux_diagrams()`.
+		:func:`~kda.diagrams.generate_all_flux_diagrams()`.
 		"""
 		self.flux_diagrams = diagrams.generate_all_flux_diagrams(self.G)
 
@@ -135,7 +135,7 @@ class KineticModel(object):
 		have already been generated with
 		:meth:`~kda.core.KineticModel.build_partial_diagrams()`
 		the count will simply be returned. Otherwise
-		:meth:`~kda.diagrams.enumerate_partial_diagrams()` is used.
+		:func:`~kda.diagrams.enumerate_partial_diagrams()` is used.
 
 		Returns
 		=======
@@ -172,7 +172,7 @@ class KineticModel(object):
 	def get_flux_diagrams(self, cycle):
 		"""
 		Retrieves the flux diagrams for a specific cycle using
-		:meth:`~kda.diagrams.generate_flux_diagrams()`.
+		:func:`~kda.diagrams.generate_flux_diagrams()`.
 
 		Parameters
 		==========
@@ -193,12 +193,12 @@ class KineticModel(object):
 	def build_state_probabilities(self, symbolic=True):
 		"""
 		Builds the state probabilities for the kinetic diagram using
-		:meth:`~kda.calculations.calc_state_probs()`. Probabilities
+		:func:`~kda.calculations.calc_state_probs()`. Probabilities
 		can be stored as raw values or symbolic algebraic expressions.
 
 		Parameters
 		==========
-		symbolic : bool (optional)
+		symbolic : bool, optional
 			Used to determine whether raw values or symbolic
 			expressions will be stored. Default is ``True``.
 		"""
@@ -228,11 +228,11 @@ class KineticModel(object):
 			The index (index 1) of the initial state.
 		state_j : integer
 			The index (index 1) of the final state.
-		net : bool (optional)
+		net : bool, optional
 			Used to determine whether one-way transition fluxes
 			or net transition fluxes will be returned. Default
 			is ``True``.
-		symbolic : bool (optional)
+		symbolic : bool, optional
 			Used to determine whether raw values or symbolic
 			expressions will be returned. Default is ``True``.
 
@@ -305,4 +305,3 @@ class KineticModel(object):
 				return j_ij - j_ji
 			else:
 				return j_ij
-

--- a/kda/diagrams.py
+++ b/kda/diagrams.py
@@ -233,7 +233,7 @@ def _append_reverse_edges(edge_list):
 
 def _get_cofactor_matrix(K_laplace):
     """
-    Helper function for :meth:`~kda.diagrams.enumerate_partial_diagrams()`.
+    Helper function for :func:`~kda.diagrams.enumerate_partial_diagrams()`.
     Uses singular value decomposition to get the cofactor matrix for
     the input Laplacian matrix.
 

--- a/kda/graph_utils.py
+++ b/kda/graph_utils.py
@@ -64,15 +64,15 @@ def generate_edges(G, vals, names=None, val_key="val", name_key="name"):
         the kinetic rate *values* for each transition in ``G``. For example,
         assuming we have some values ``k12_val`` and ``k21_val``, for a
         2-state diagram ``vals = [[0, k12_val], [k21_val, 0]]``.
-    names : ndarray (optional)
+    names : ndarray, optional
         ``NxN`` array where ``N`` is the number of nodes in ``G``. Contains
         the kinetic rate *variable names* (as strings) for each transition
         in ``G``. For example, for a 2-state diagram
         ``names = [[0, "k12"], ["k21", 0]]``.
-    val_key : str (optional)
+    val_key : str, optional
         Attribute key used to retrieve kinetic rate *values* from the
         edge data stored in ``G.edges``. The default is ``"val"``.
-    name_key : str (optional)
+    name_key : str, optional
         Attribute key used to retrieve kinetic rate *variable names* from
         the edge data stored in ``G.edges``. The default is ``"name"``.
     """
@@ -101,7 +101,7 @@ def retrieve_rate_matrix(G, key="val"):
     ----------
     G : ``NetworkX.MultiDiGraph``
         A kinetic diagram
-    key : str
+    key : str, optional
         Attribute key used to retrieve edge data from ``G.edges``. The default
         ``NetworkX`` edge key is ``"weight"``, however the ``kda`` edge keys
         are ``"name"`` (for rate constant names, e.g. ``"k12"``) and ``"val"``
@@ -177,8 +177,8 @@ def _is_ccw(cycle, start, end):
 def get_ccw_cycle(cycle, order):
     """
     Function used for obtaining the CCW version of an input cycle, primarily
-    used for :meth:`~kda.calculations.calculate_pi_difference()` and
-    :meth:`~kda.calculations.calculate_thermo_force()`.
+    used for :func:`~kda.calculations.calculate_pi_difference()` and
+    :func:`~kda.calculations.calculate_thermo_force()`.
 
     Parameters
     ----------

--- a/kda/ode.py
+++ b/kda/ode.py
@@ -36,7 +36,7 @@ def ode_solver(P, K, t_max, method="LSODA", tol=1e-16, **options):
         Integration method used in ``scipy.integrate.solve_ivp()``. Default is
         ``"LSODA"`` since it has automatic stiffness detection, and generally
         requires much less run time to reach convergence than ``"RK45"``.
-    tol : float (optional)
+    tol : float, optional
         Tolerance value used as convergence criteria. Once all dp/dt values for
         each state are less than the tolerance the integrator will terminate.
         Default is ``1e-16``.

--- a/kda/plotting.py
+++ b/kda/plotting.py
@@ -8,16 +8,16 @@ Diagram Plotting
 =========================================================================
 The :mod:`~kda.plotting` module contains code to plot partial diagrams
 (undirected spanning trees), directional diagrams, and flux diagrams, as
-well as cycles and :meth:`~kda.ode.ode_solver` results.
+well as cycles and :func:`~kda.ode.ode_solver` results.
 
 The two main functions used for plotting KDA-generated diagrams are
-:meth:`~kda.plotting.draw_diagrams` and :meth:`~kda.plotting.draw_cycles`.
+:func:`~kda.plotting.draw_diagrams` and :func:`~kda.plotting.draw_cycles`.
 ``draw_diagrams`` is used for plotting kinetic diagrams, partial diagrams,
 directional diagrams, and flux diagrams, while ``draw_cycles`` is used for
 plotting cycles in the kinetic diagram.
 
 For example, for a 4-state model we start by generating the
-:meth:`~kda.core.KineticModel` and plotting the kinetic diagram:
+:class:`~kda.core.KineticModel` and plotting the kinetic diagram:
 
 .. code-block:: python
 
@@ -194,7 +194,7 @@ def _get_axis_limits(pos, scale_factor=1.4):
         Dictionary where keys are the indexed states (e.g. 0, 1,
         2, ..., ``N``) and the values are the x, y coordinates for
         each node.
-    scale_factor: float (optional)
+    scale_factor: float, optional
         Factor used to scale the x/y axis limits. Default is ``1.4``.
 
     Returns
@@ -228,7 +228,7 @@ def _get_panel_dimensions(n_diagrams, rows, cols=None):
     rows : int
         Number of rows, typically based on the square
         root of the number of diagrams to generate.
-    cols : int (optional)
+    cols : int, optional
         Number of columns. Default is ``None``, which results in the number
         of rows being determined based on the number of diagrams input.
 
@@ -272,45 +272,45 @@ def _plot_single_diagram(
     ----------
     diagram : ``NetworkX.MultiDiGraph`` or ``NetworkX.Graph``
         Diagram to be plotted.
-    pos : dict (optional)
+    pos : dict, optional
         Dictionary where keys are the indexed states (e.g. 0, 1, 2,
         ..., ``N``) and the values are the x, y coordinates for each
         node. If not specified, ``NetworkX.spring_layout()`` is used.
-    node_labels: dict (optional)
+    node_labels: dict, optional
         Dictionary where keys are the node index (index-zero) and the
         keys are the node index string (index-one). If not specified, labels
         will be created for all nodes in the input diagram.
-    node_list : list (optional)
+    node_list : list, optional
         List of node indices (e.g. ``[0, 2, 3, 1]``) indicating
         which nodes to plot. If not specified, all nodes in the input
         diagram will be plotted.
-    node_colors: list (optional)
+    node_colors: list, optional
         List of strings of color values (e.g. ``["0.8", "0.8",...]``)
         used to color the nodes. If not specified, node colors will
         be determined using the ``cbt`` parameter.
-    edge_list: list (optional)
+    edge_list: list, optional
         List of edge tuples (e.g. ``[(1, 0), (1, 2), ...]``) to plot. If not
         specified, all edges will be plotted.
-    font_size : int (optional)
+    font_size : int, optional
         Sets the font size for the figure. Default is ``12``.
-    figsize: tuple (optional)
+    figsize: tuple, optional
         Tuple of the form ``(x, y)``, where ``x`` and ``y`` are the
         x and y-axis figure dimensions in inches. Default is ``(3, 3)``.
-    node_size: int (optional)
+    node_size: int, optional
         Size of nodes used for ``NetworkX`` diagram. Default is ``300``.
-    arrow_width: float (optional)
+    arrow_width: float, optional
         Arrow width used for ``NetworkX`` diagram. Default is ``1.5``.
-    arrow_size: int (optional)
+    arrow_size: int, optional
         Arrow size used for ``NetworkX`` diagram. Default is ``12``.
-    arrow_style: str (optional)
+    arrow_style: str, optional
         Style of arrows used for ``NetworkX`` diagram. Default is ``"->"``.
-    connection_style: str (optional)
+    connection_style: str, optional
         Style of arrow connections for ``NetworkX`` diagram.
         Default is ``"arc3"``.
-    ax: ``matplotlib`` axis object (optional)
+    ax: ``matplotlib`` axis object, optional
         Axis to place diagrams on. If not specified, a new figure
         and axis will be created. Default is ``None``.
-    cbt : bool (optional)
+    cbt : bool, optional
         'Color by target' option that paints target nodes with a coral red.
         Typically used for plotting directional and flux diagrams.
         Default is ``False``.
@@ -391,26 +391,26 @@ def _plot_panel(
     ----------
     diagrams : list of cycles or ``NetworkX`` graph objects
         List of diagrams or single diagram to be plotted.
-    rows : int (optional)
+    rows : int, optional
         Number of rows. Default is ``None``, which results in the number
         of rows being determined based on the number of diagrams input.
-    cols : int (optional)
+    cols : int, optional
         Number of columns. Default is ``None``, which results in the number
         of columns being determined based on the number of diagrams input.
-    pos : dict (optional)
+    pos : dict, optional
         Dictionary where keys are the indexed states (e.g. 0, 1, 2,
         ..., ``N``) and the values are the x, y coordinates for each
         node. If not specified, ``NetworkX.spring_layout()`` is used.
-    panel_scale : float (optional)
+    panel_scale : float, optional
         Parameter used to scale figure if ``panel=True``. Linearly
         scales figure height and width. Default is ``2``.
-    font_size : int (optional)
+    font_size : int, optional
         Sets the font size for the figure. Default is ``12``.
-    cbt : bool (optional)
+    cbt : bool, optional
         'Color by target' option that paints target nodes with a
         coral red. Typically used for plotting directional and flux
         diagrams. Default is ``False``.
-    curved_arrows: bool (optional)
+    curved_arrows: bool, optional
         Switches on arrows with a slight curvature to separate double arrows
         for directional diagrams. Default is ``False``.
 
@@ -480,37 +480,37 @@ def draw_diagrams(
     ----------
     diagrams : list of ``NetworkX`` graph objects
         List of diagrams or single diagram to be plotted.
-    pos : dict (optional)
+    pos : dict, optional
         Dictionary where keys are the indexed states (e.g. 0, 1, 2,
         ..., ``N``) and the values are the x, y coordinates for each
         node. If not specified, ``NetworkX.spring_layout()`` is used.
-    panel : bool (optional)
+    panel : bool, optional
         Tells the function to output diagrams as an ``NxM`` matrix of subplots,
         where ``N`` and ``M`` are the number of rows and columns, respectively.
         ``True`` will output a panel figure, ``False`` will output each figure
         individually. Default is ``False``.
-    panel_scale : float (optional)
+    panel_scale : float, optional
         Parameter used to scale figure if ``panel=True``. Linearly
         scales figure height and width. Default is ``2``.
-    font_size : int (optional)
+    font_size : int, optional
         Sets the font size for the figure. Default is ``12``.
-    cbt : bool (optional)
+    cbt : bool, optional
         'Color by target' option that paints target nodes with a
         coral red. Typically used for plotting directional and flux
         diagrams. Default is ``False``.
-    rows : int (optional)
+    rows : int, optional
         Number of rows. Default is ``None``, which results in the number
         of rows being determined based on the number of diagrams input.
-    cols : int (optional)
+    cols : int, optional
         Number of columns. Default is ``None``, which results in the number
         of columns being determined based on the number of diagrams input.
-    path : str (optional)
+    path : str, optional
         String of save path for figure. If a path is specified the figure(s)
         will be saved at the specified location. Default is ``None``.
-    label : str (optional)
+    label : str, optional
         Figure label used to create unique filename if ``path`` is
         input. Includes ``.png`` file extension. Default is ``None``.
-    curved_arrows: bool (optional)
+    curved_arrows: bool, optional
         Switches on arrows with a slight curvature to separate double arrows
         for directional diagrams. Default is ``False``.
 
@@ -521,7 +521,7 @@ def draw_diagrams(
 
     Examples
     --------
-    The :meth:`~kda.plotting.draw_diagrams` function allows for easy
+    The :func:`~kda.plotting.draw_diagrams` function allows for easy
     plotting of KDA-generated diagrams:
 
     .. code-block:: python
@@ -652,30 +652,30 @@ def draw_cycles(
     cycles : list of lists of int
         List of cycles or individual cycle to be plotted, index zero. Order
         of node indices does not matter.
-    pos : dict (optional)
+    pos : dict, optional
         Dictionary where keys are the indexed states (e.g. 0, 1, 2,
         ..., ``N``) and the values are the x, y coordinates for each
         node. If not specified, ``NetworkX.spring_layout()`` is used.
-    panel : bool (optional)
+    panel : bool, optional
         Tells the function to output diagrams as an ``NxM`` matrix of subplots,
         where ``N`` and ``M`` are the number of rows and columns, respectively.
         ``True`` will output a panel figure, ``False`` will output each figure
         individually. Default is ``False``.
-    panel_scale : float (optional)
+    panel_scale : float, optional
         Parameter used to scale figure if ``panel=True``. Linearly
         scales figure height and width. Default is ``2``.
-    font_size : int (optional)
+    font_size : int, optional
         Sets the font size for the figure. Default is ``12``.
-    cbt : bool (optional)
+    cbt : bool, optional
         'Color by target' option that paints target nodes with a
         coral red. Default is ``False``.
-    curved_arrows: bool (optional)
+    curved_arrows: bool, optional
         Switches on arrows with a slight curvature to separate double arrows
         for directional diagrams. Default is ``False``.
-    path : str (optional)
+    path : str, optional
         String of save path for figure. If a path is specified the figure(s)
         will be saved at the specified location. Default is ``None``.
-    label : str (optional)
+    label : str, optional
         Figure label used to create unique filename if ``path`` is
         input. Includes ``.png`` file extension. Default is ``None``.
 
@@ -686,7 +686,7 @@ def draw_cycles(
 
     Examples
     --------
-    The :meth:`~kda.plotting.draw_cycles` function allows for easy
+    The :func:`~kda.plotting.draw_cycles` function allows for easy
     plotting of cycles in kinetic diagrams:
 
     .. code-block:: python
@@ -845,26 +845,26 @@ def draw_ode_results(
 ):
     """
     Plots probability time series for all states generated
-    by :meth:`~kda.ode.ode_solver`.
+    by :func:`~kda.ode.ode_solver`.
 
     Parameters
     ----------
     results : ``Bunch`` object
         Contains time information (``results.t``) and function information
         at time ``t`` (``results.y``), as well as various other fields.
-    figsize: tuple (optional)
+    figsize: tuple, optional
         Tuple of the form ``(x, y)``, where ``x`` and ``y`` are the x and
         y-axis figure dimensions in inches. Default is ``(5, 4)``.
-    legendloc : str (optional)
+    legendloc : str, optional
         String passed to determine where to place the legend for the figure.
         Default is ``"best"``.
-    bbox_coords : tuple (optional)
+    bbox_coords : tuple, optional
         Tuple of the form ``(x, y)``, where ``x`` and ``y`` are the x
         and y-axis coordinates for the legend. Default is ``None``.
-    path : str (optional)
+    path : str, optional
         String of save path for figure. If a path is specified the figure
         will be saved at the specified location. Default is ``None``.
-    label : str (optional)
+    label : str, optional
         Figure label used to create unique filename if ``path`` is
         input. Includes ``.png`` file extension. Default is ``None``.
 

--- a/kda/svd.py
+++ b/kda/svd.py
@@ -30,7 +30,7 @@ def svd_solver(K, tol=1e-12):
         ``kij`` is the edge weight (i.e. transition rate constant).
         For example, for a 2-state model with ``k12=3`` and ``k21=4``,
         ``K=[[0, 3], [4, 0]]``.
-    tol : float (optional)
+    tol : float, optional
         Tolerance used for singular value determination. Values are
         considered singular if they are less than the input tolerance.
         Default is ``1e-12``.


### PR DESCRIPTION
## Description

* Fixes incorrect usage of `(optional)` instead of `, optional` for optional parameters in function/method docstrings

* Updates docstrings with `key` parameter to correctly list them as an `optional` parameter

* Updates function, method, and class references to use their correct tag (i.e. `:func:` for functions, `:class:` for classes) instead of using `:meth:`

## Status
- [ ] Ready to go